### PR TITLE
docs: clarify how-to-use example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,48 @@ To install, since we do not publish this package to PyPI, add this library to yo
 ```sh
 pip install 'git+https://github.com/dClimate/py-hamt'
 ```
-See the [code documentation](https://dclimate.github.io/py-hamt/py_hamt.html) for more on usage. Looking at the test files, namely `test_hamt.py` is also quite helpful.
+
+### Basic Writing/Reading from an in memory store
+```python
+    from py_hamt import HAMT, DictStore
+
+    # Setup a HAMT with an in memory store, 
+    in_memory_store = DictStore()
+    hamt = HAMT(store=in_memory_store)
+
+    # Set and get one value
+    hamt["foo"] = "bar"
+    assert "bar" == hamt["foo"]
+    assert len(hamt) == 1
+
+    # Set and get multiple values
+    hamt["foo"] = "bar1"
+    hamt["foo2"] = 2
+    assert 2 == hamt["foo2"]
+    assert len(hamt) == 2
+
+    # Iterate over keys
+    for key in hamt:
+        print(key)
+    print (list(hamt)) # [foo, foo2], order depends on the hash function used
+
+    # Delete a value
+    del hamt["foo"]
+    assert len(hamt) == 1
+```
+
+### Reading a CID from IPFS 
+```python
+    from py_hamt import HAMT, IPFSStore
+
+    # Create HAMT instance using the IPFSStore connecting to your locally 
+    # running IPFS Gateway from your local running IPFS Node, Change the IP
+    # port for your running IPFS instance
+    hamt = HAMT(store=IPFSStore(gateway_uri_stem="http://0.0.0.0:8080"), root_node_id=root_cid)
+    # Do something with the keys 
+```
+
+See the [code documentation](https://dclimate.github.io/py-hamt/py_hamt.html) for more on usage. Looking at the test files, namely `test_hamt.py` is also quite helpful. You can also see this library used in notebooks for data analysis here [dClimate Jupyter Notebooks](https://github.com/dClimate/jupyter-notebooks)
 
 # Development Guide
 ## Setting Up

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install 'git+https://github.com/dClimate/py-hamt'
 ```python
     from py_hamt import HAMT, DictStore
 
-    # Setup a HAMT with an in memory store, 
+    # Setup a HAMT with an in memory store 
     in_memory_store = DictStore()
     hamt = HAMT(store=in_memory_store)
 
@@ -52,12 +52,21 @@ pip install 'git+https://github.com/dClimate/py-hamt'
 ### Reading a CID from IPFS 
 ```python
     from py_hamt import HAMT, IPFSStore
+    from multiformats import CID
+
+    # Get the CID you wish to read whether from a blog post, a smart contract, or a friend
+    dataset_cid = "baf..."
+
+    # Use the multiformats library to decode the CID into an object
+    root_cid = CID.decode(dataset_cid)
 
     # Create HAMT instance using the IPFSStore connecting to your locally 
-    # running IPFS Gateway from your local running IPFS Node, Change the IP
-    # port for your running IPFS instance
-    hamt = HAMT(store=IPFSStore(gateway_uri_stem="http://0.0.0.0:8080"), root_node_id=root_cid)
-    # Do something with the keys 
+    # running IPFS Gateway from your local running IPFS Node, If you wish 
+    # you can change the default IPFS gateway
+    hamt = HAMT(store=IPFSStore(root_node_id=root_cid) # You can optionally pass your own gateway instead of defaults with the argument gateway_uri_stem="http://<IP>:<PORT>",
+
+    # Do something with the hamt key/values
+    ... 
 ```
 
 See the [code documentation](https://dclimate.github.io/py-hamt/py_hamt.html) for more on usage. Looking at the test files, namely `test_hamt.py` is also quite helpful. You can also see this library used in notebooks for data analysis here [dClimate Jupyter Notebooks](https://github.com/dClimate/jupyter-notebooks)

--- a/py_hamt/hamt.py
+++ b/py_hamt/hamt.py
@@ -132,18 +132,27 @@ class HAMT(MutableMapping):
     ```python
     from py_hamt import HAMT, DictStore
 
+    # Setup a HAMT with an in memory store, one could also use IPFSStore or any other store that implements the Store interface
     in_memory_store = DictStore()
     hamt = HAMT(store=in_memory_store)
+
+    # Set and get one value
     hamt["foo"] = "bar"
     assert "bar" == hamt["foo"]
     assert len(hamt) == 1
+
+    # Set and get multiple values
     hamt["foo"] = "bar1"
     hamt["foo2"] = 2
     assert 2 == hamt["foo2"]
     assert len(hamt) == 2
+
+    # Iterate over keys
     for key in hamt:
         print(key)
     print (list(hamt)) # [foo, foo2], order depends on the hash function used
+
+    # Delete a value
     del hamt["foo"]
     assert len(hamt) == 1
     ```


### PR DESCRIPTION
As a noobie user I usually want to click fewer links and immediately get to know how something works without looking at the docs, I think this hopefully gets us there (also added some spaces and comments to the docs one as well to clarify at a quick glance what's going on)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/dClimate/py-hamt/28)
<!-- GitContextEnd -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Enhanced user guidance by adding new sections with practical Python examples.
	- Demonstrated how to perform basic operations using an in-memory store.
	- Provided clear usage instructions for connecting to an IPFS store via a local gateway.
	- Clarified thread safety and hash function details in the `HAMT` class documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->