### PR TITLE
refactor: add mypy typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,7 @@ repos:
       - id: slotscheck
         name: slotscheck
         entry: bash -c 'env PYTHONPATH=src slotscheck'
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: "v1.15.0"
+    hooks:
+      - id: mypy

--- a/py_hamt/hamt.py
+++ b/py_hamt/hamt.py
@@ -623,7 +623,7 @@ class HAMT:
         raw_hash: bytes = self.hash_fn(key.encode())
 
         current_id: IPLDKind = self.root_node_id
-        current_depth = 0
+        current_depth: int = 0
 
         # Don't check if result is none but use a boolean to indicate finding something, this is because None is a possible value of IPLDKind
         result_ptr: IPLDKind = None
@@ -643,7 +643,7 @@ class HAMT:
                     break
 
             if isinstance(item, list):
-                link = item[0]
+                link: IPLDKind = item[0]
                 current_id = link
                 current_depth += 1
                 continue
@@ -658,10 +658,10 @@ class HAMT:
 
     # Callers MUST handle locking or not on their own
     async def _iter_nodes(self) -> AsyncIterator[tuple[IPLDKind, Node]]:
-        node_id_stack = [self.root_node_id]
+        node_id_stack: List[IPLDKind] = [self.root_node_id]
         while len(node_id_stack) > 0:
-            top_id = node_id_stack.pop()
-            node = await self.node_store.load(top_id)
+            top_id: IPLDKind = node_id_stack.pop()
+            node: Node = await self.node_store.load(top_id)
             yield (top_id, node)
             node_id_stack.extend(list(node.iter_links()))
 
@@ -693,7 +693,7 @@ class HAMT:
 
         When the HAMT is write enabled, to maintain strong consistency it will acquire a lock and thus not allow any other operations to proceed until the length is fully done being calculated. If read only, then this can be run concurrently with other operations.
         """
-        count = 0
+        count: int = 0
         async for _ in self.keys():
             count += 1
 

--- a/py_hamt/store.py
+++ b/py_hamt/store.py
@@ -1,6 +1,6 @@
 import asyncio
 import aiohttp
-from typing import Literal
+from typing import Literal, Optional, Dict, cast, Any
 from abc import ABC, abstractmethod
 from dag_cbor.ipld import IPLDKind
 from multiformats import multihash
@@ -37,7 +37,7 @@ class ContentAddressedStore(ABC):
 class InMemoryCAS(ContentAddressedStore):
     """Used mostly for faster testing, this is why this is not exported. It hashes all inputs and uses that as a key to an in-memory python dict, mimicking a content addressed storage system. The hash bytes are the ID that `save` returns and `load` takes in."""
 
-    store: dict[bytes, bytes]
+    store: Dict[bytes, bytes]
     hash_alg: Multihash
 
     def __init__(self):
@@ -45,7 +45,7 @@ class InMemoryCAS(ContentAddressedStore):
         self.hash_alg = multihash.get("blake3")
 
     async def save(self, data: bytes, codec: ContentAddressedStore.CodecInput) -> bytes:
-        hash = self.hash_alg.digest(data, size=32)
+        hash: bytes = self.hash_alg.digest(data, size=32)
         self.store[hash] = data
         return hash
 
@@ -63,10 +63,10 @@ class KuboCAS(ContentAddressedStore):
     `save` uses the RPC API and `load` uses the HTTP Gateway. This means that read-only HAMTs will only access the HTTP Gateway, so no RPC endpoint is required for use.
     """
 
-    KUBO_DEFAULT_LOCAL_GATEWAY_BASE_URL = "http://127.0.0.1:8080"
-    KUBO_DEFAULT_LOCAL_RPC_BASE_URL = "http://127.0.0.1:5001"
+    KUBO_DEFAULT_LOCAL_GATEWAY_BASE_URL: str = "http://127.0.0.1:8080"
+    KUBO_DEFAULT_LOCAL_RPC_BASE_URL: str = "http://127.0.0.1:5001"
 
-    DAG_PB_MARKER = 0x70
+    DAG_PB_MARKER: int = 0x70
     """@private"""
 
     # Take in a aiohttp session that can be reused across POSTs and GETs to a specific ipfs daemon, also allow for not doing that and creating our own single request lifetime session instead
@@ -90,7 +90,7 @@ class KuboCAS(ContentAddressedStore):
         These are the first part of the url, defaults that refer to the default that kubo launches with on a local machine are provided.
         """
 
-        self.hasher = hasher
+        self.hasher: str = hasher
         """The hash function to send to IPFS when storing bytes. Cannot be changed after initialization. The default blake3 follows the default hashing algorithm used by HAMT."""
 
         if rpc_base_url is None:
@@ -98,9 +98,9 @@ class KuboCAS(ContentAddressedStore):
         if gateway_base_url is None:
             gateway_base_url = KuboCAS.KUBO_DEFAULT_LOCAL_GATEWAY_BASE_URL
 
-        self.rpc_url = f"{rpc_base_url}/api/v0/add?hash={self.hasher}&pin=false"
+        self.rpc_url: str = f"{rpc_base_url}/api/v0/add?hash={self.hasher}&pin=false"
         """@private"""
-        self.gateway_base_url = gateway_base_url + "/ipfs/"
+        self.gateway_base_url: str = f"{gateway_base_url}/ipfs/"
         """@private"""
 
         self._session_per_loop: dict[
@@ -110,17 +110,17 @@ class KuboCAS(ContentAddressedStore):
         if session is not None:
             # user supplied → bind it to *their* current loop
             self._session_per_loop[asyncio.get_running_loop()] = session
-            self._owns_session = False
+            self._owns_session: bool = False
         else:
             self._owns_session = True  # we’ll create sessions lazily
 
-        self._sem = asyncio.Semaphore(64)
+        self._sem: asyncio.Semaphore = asyncio.Semaphore(64)
 
     # --------------------------------------------------------------------- #
     # helper: get or create the session bound to the current running loop   #
     # --------------------------------------------------------------------- #
     def _loop_session(self) -> aiohttp.ClientSession:
-        loop = asyncio.get_running_loop()
+        loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
         try:
             return self._session_per_loop[loop]
         except KeyError:
@@ -134,16 +134,16 @@ class KuboCAS(ContentAddressedStore):
     # --------------------------------------------------------------------- #
     # graceful shutdown: close **all** sessions we own                      #
     # --------------------------------------------------------------------- #
-    async def aclose(self):
+    async def aclose(self) -> None:
         if self._owns_session:
             for sess in list(self._session_per_loop.values()):
                 if not sess.closed:
                     await sess.close()
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> "KuboCAS":
         return self
 
-    async def __aexit__(self, *exc):
+    async def __aexit__(self, *exc: Any) -> None:
         await self.aclose()
 
     # --------------------------------------------------------------------- #
@@ -158,18 +158,17 @@ class KuboCAS(ContentAddressedStore):
 
             async with self._loop_session().post(self.rpc_url, data=form) as resp:
                 resp.raise_for_status()
-                cid_str = (await resp.json())["Hash"]
+                cid_str: str = (await resp.json())["Hash"]
 
-        cid = CID.decode(cid_str)
+        cid: CID = CID.decode(cid_str)
         if cid.codec.code != self.DAG_PB_MARKER:
             cid = cid.set(codec=codec)
         return cid
 
-    async def load(  # type: ignore CID is definitely in the IPLDKind type
-        self, id: CID
-    ) -> bytes:
+    async def load(self, id: IPLDKind) -> bytes:
         """@private"""
-        url = self.gateway_base_url + str(id)
+        cid = cast(CID, id)  # CID is definitely in the IPLDKind type
+        url: str = self.gateway_base_url + str(cid)
         async with self._sem:  # throttle gateway
             async with self._loop_session().get(url) as resp:
                 resp.raise_for_status()

--- a/py_hamt/zarr_hamt_store.py
+++ b/py_hamt/zarr_hamt_store.py
@@ -1,5 +1,5 @@
 from collections.abc import AsyncIterator, Iterable
-from typing import Optional, Dict, List, Tuple, cast
+from typing import cast
 import zarr.abc.store
 import zarr.core.buffer
 from zarr.core.common import BytesLike

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,4 +31,5 @@ dev = [
     "pytest-asyncio>=0.25.3",
     "xarray[complete]>=2025.3.0",
     "mypy>=1.15.0",
+    "pandas-stubs>=2.2.3.250527",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,4 +30,5 @@ dev = [
     "numpy>=2.1.3",
     "pytest-asyncio>=0.25.3",
     "xarray[complete]>=2025.3.0",
+    "mypy>=1.15.0",
 ]

--- a/tests/performance_tests.py
+++ b/tests/performance_tests.py
@@ -13,21 +13,21 @@ from py_hamt.store import InMemoryCAS
 
 
 @pytest.mark.asyncio
-async def test_large_kv_set():
+async def test_large_kv_set() -> None:
     """This test is meant for finding whether the HAMT performance scales linearly with increasing set size, an issue with HAMT v2.
     Feel free to tune and run the LARGE_KV_SET_SIZE variable as needed for gathering the different timepoints.
     """
-    LARGE_KV_SET_SIZE = 1_000_000
+    LARGE_KV_SET_SIZE: int = 1_000_000
 
     cas = InMemoryCAS()
     hamt = await HAMT.build(cas=cas)
-    start = time.perf_counter()
+    start: float = time.perf_counter()
     await asyncio.gather(
         *[hamt.set(str(k_int), k_int) for k_int in range(LARGE_KV_SET_SIZE)]
     )
     await hamt.make_read_only()
-    end = time.perf_counter()
-    elapsed = end - start
+    end: float = time.perf_counter()
+    elapsed: float = end - start
     print(f"Took {elapsed:.2f} seconds")
     assert (
         len([key async for key in hamt.keys()])

--- a/tests/test_extract_bits.py
+++ b/tests/test_extract_bits.py
@@ -3,7 +3,7 @@ import pytest
 
 
 # Most of these tests were adapted over to python from rvagg's IAMap tests in JS
-def test_extract_bits():
+def test_extract_bits() -> None:
     assert extract_bits(bytes([0b11111111]), 0, 5) == 0b11111
     assert extract_bits(bytes([0b10101010]), 0, 5) == 0b10101
     assert extract_bits(bytes([0b10000000]), 0, 5) == 0b10000

--- a/tests/test_hamt.py
+++ b/tests/test_hamt.py
@@ -5,7 +5,7 @@ from dag_cbor import IPLDKind
 from multiformats import CID
 from hypothesis import given, settings
 from hypothesis import strategies as st
-from typing import List, Tuple, Set, cast, Callable, Coroutine, Any
+from typing import cast
 import pytest
 
 from py_hamt.hamt import HAMT, Node

--- a/tests/test_hamt.py
+++ b/tests/test_hamt.py
@@ -5,6 +5,7 @@ from dag_cbor import IPLDKind
 from multiformats import CID
 from hypothesis import given, settings
 from hypothesis import strategies as st
+from typing import List, Tuple, Set, cast, Callable, Coroutine, Any
 import pytest
 
 from py_hamt.hamt import HAMT, Node
@@ -18,7 +19,7 @@ from testing_utils import key_value_list
 @settings(
     deadline=1000
 )  # increase for github CI which sometimes takes longer than the default 250 ms
-async def test_fuzz(kvs: list[tuple[str, IPLDKind]]):
+async def test_fuzz(kvs: list[tuple[str, IPLDKind]]) -> None:
     cas = InMemoryCAS()
     hamt = await HAMT.build(cas=cas)
 
@@ -39,7 +40,7 @@ async def test_fuzz(kvs: list[tuple[str, IPLDKind]]):
     await hamt.make_read_only()
 
     # Verify completely concurrently
-    async def verify(k, v):
+    async def verify(k: str, v: IPLDKind):
         assert (await hamt.get(k)) == v
 
     await asyncio.gather(*[verify(k, v) for k, v in kvs])
@@ -57,7 +58,7 @@ async def test_fuzz(kvs: list[tuple[str, IPLDKind]]):
     await hamt.enable_write()
 
     # HAMT should be throwing errors on keys that do not exist
-    ks = [k for k, _ in kvs]
+    ks: list[str] = [k for k, _ in kvs]
     key_that_cannot_exist = "".join(ks).join(
         "string to account for empty string key case"
     )
@@ -66,9 +67,9 @@ async def test_fuzz(kvs: list[tuple[str, IPLDKind]]):
     with pytest.raises(KeyError):
         await hamt.delete(key_that_cannot_exist)
 
-    hamt_keys = [key async for key in hamt.keys()]
-    hamt_key_set = set(hamt_keys)
-    keys_set = set()
+    hamt_keys: list[str] = [key async for key in hamt.keys()]
+    hamt_key_set: set[str] = set(hamt_keys)
+    keys_set: set[str] = set()
     for key, _ in kvs:
         keys_set.add(key)
 
@@ -76,7 +77,9 @@ async def test_fuzz(kvs: list[tuple[str, IPLDKind]]):
 
     # Make sure all pointers actually exist in the store, this should not raise any exceptions
     for k, _ in kvs:
-        pointer: bytes = await hamt.get_pointer(k)  # type: ignore we know that InMemoryCAS only returns bytes for its IDs
+        pointer: bytes = cast(
+            bytes, await hamt.get_pointer(k)
+        )  # we know that InMemoryCAS only returns bytes for its IDs
         await cas.load(pointer)
 
     await hamt.make_read_only()
@@ -85,7 +88,7 @@ async def test_fuzz(kvs: list[tuple[str, IPLDKind]]):
     with pytest.raises(Exception, match="Cannot call delete on a read only HAMT"):
         await hamt.delete("foo")
 
-    async def verify_kvs_and_len(h: HAMT):
+    async def verify_kvs_and_len(h: HAMT) -> None:
         for k, v in kvs:
             assert (await h.get(k)) == v
         assert len([key async for key in h.keys()]) == (await h.len()) == len(kvs)
@@ -121,13 +124,13 @@ async def test_fuzz(kvs: list[tuple[str, IPLDKind]]):
 
     # Cache size management code branches coverage, do it all in async concurrency
 
-    small_cache_size_bytes = 1000
+    small_cache_size_bytes: int = 1000
     # Read cache
     read_hamt = await HAMT.build(
         cas=cas, root_node_id=hamt.root_node_id, read_only=True
     )
 
-    async def get_and_vacate(k, v):
+    async def get_and_vacate(k: str, v: IPLDKind) -> None:
         assert (await read_hamt.get(k)) == v
         if (await read_hamt.cache_size()) > small_cache_size_bytes:
             await read_hamt.cache_vacate()
@@ -139,7 +142,7 @@ async def test_fuzz(kvs: list[tuple[str, IPLDKind]]):
     # set small max bucket size to force more linking and more nodes
     small_memory_tree = await HAMT.build(cas=cas, max_bucket_size=1)
 
-    async def set_and_vacate(k, v):
+    async def set_and_vacate(k: str, v: IPLDKind) -> None:
         await small_memory_tree.set(k, v)
         assert (await small_memory_tree.get(k)) == v
         if (await small_memory_tree.cache_size()) > small_cache_size_bytes:

--- a/tests/test_kubo_cas.py
+++ b/tests/test_kubo_cas.py
@@ -19,6 +19,30 @@ async def test_memory_store_exception():
         await s.load(bytes())
 
 
+@pytest.mark.asyncio
+async def test_memory_store_invalid_key_type():
+    """Test that InMemoryCAS.load raises TypeError for non-bytes keys"""
+    s = InMemoryCAS()
+
+    # Test with various non-bytes types
+    invalid_keys = [
+        "string_key",
+        123,
+        12.34,
+        ["list", "key"],
+        {"dict": "key"},
+        None,
+        True,
+    ]
+
+    for invalid_key in invalid_keys:
+        with pytest.raises(
+            TypeError,
+            match=f"InMemoryCAS only supports byte‐hash keys; got {type(invalid_key).__name__}",
+        ):
+            await s.load(invalid_key)
+
+
 @pytest.mark.asyncio(loop_scope="session")
 @given(data=ipld_strategy())
 @settings(
@@ -52,9 +76,9 @@ async def test_kubo_default_urls(
                 # print(f"Loaded encoded data length: {len(loaded_encoded_data)}")
                 result = dag_cbor.decode(loaded_encoded_data)
                 # print(f"Decoded result: {result}")
-                assert data == result, (
-                    f"Data mismatch for codec {codec} with default URLs"
-                )
+                assert (
+                    data == result
+                ), f"Data mismatch for codec {codec} with default URLs"
             except Exception as e:
                 pytest.fail(
                     f"Error during KuboCAS default URL test (codec: {codec}): {e}"

--- a/tests/test_kubo_cas.py
+++ b/tests/test_kubo_cas.py
@@ -1,6 +1,7 @@
 import aiohttp
 import dag_cbor
 from dag_cbor import IPLDKind
+from typing import Literal, cast
 from hypothesis import given, settings
 import pytest
 
@@ -36,10 +37,16 @@ async def test_kubo_default_urls(
     async with KuboCAS(session=global_client_session) as kubo_cas_default:
         # print(f"Testing with default URLs: RPC={kubo_cas_default.rpc_base_url}, Gateway={kubo_cas_default.gateway_base_url}")
         encoded_data = dag_cbor.encode(data)
+
         for codec in ["raw", "dag-cbor"]:
+            # The codec is a string, but we use Literal to ensure type safety
+            # where codec_raw = "raw" and codec_dag_cbor = "dag-cbor"
+            # necessary because when you iterate over a list of strings,
+            # even if they are literal strings, mypy widens the type to just str
+            codec_typed = cast(Literal["raw", "dag-cbor"], codec)
             # print(f"Saving with codec: {codec}, data: {data}")
             try:
-                cid = await kubo_cas_default.save(encoded_data, codec=codec)
+                cid = await kubo_cas_default.save(encoded_data, codec=codec_typed)
                 # print(f"Saved. CID: {cid}")
                 loaded_encoded_data = await kubo_cas_default.load(cid)
                 # print(f"Loaded encoded data length: {len(loaded_encoded_data)}")
@@ -64,8 +71,9 @@ async def test_kubo_default_urls(
         )  # Re-encode just in case, though it's the same data
         for codec in ["raw", "dag-cbor"]:
             # print(f"Saving with codec: {codec}, data: {data}")
+            codec_typed = cast(Literal["raw", "dag-cbor"], codec)
             try:
-                cid = await kubo_cas_none_urls.save(encoded_data, codec=codec)
+                cid = await kubo_cas_none_urls.save(encoded_data, codec=codec_typed)
                 # print(f"Saved. CID: {cid}")
                 loaded_encoded_data = await kubo_cas_none_urls.load(cid)
                 # print(f"Loaded encoded data length: {len(loaded_encoded_data)}")
@@ -114,7 +122,11 @@ async def test_kubo_cas(create_ipfs, data: IPLDKind):  # noqa
             gateway_base_url=gateway_base_url,
             session=session,
         ) as kubo_cas:
-            for codec in ["raw", "dag-cbor"]:
-                cid = await kubo_cas.save(dag_cbor.encode(data), codec=codec)
+            # Use proper literal types for codec
+            codec_raw: Literal["raw"] = "raw"
+            codec_dag_cbor: Literal["dag-cbor"] = "dag-cbor"
+            for codec in [codec_raw, codec_dag_cbor]:
+                codec_typed = cast(Literal["raw", "dag-cbor"], codec)
+                cid = await kubo_cas.save(dag_cbor.encode(data), codec=codec_typed)
                 result = dag_cbor.decode(await kubo_cas.load(cid))
                 assert data == result

--- a/tests/test_kubo_cas.py
+++ b/tests/test_kubo_cas.py
@@ -76,9 +76,9 @@ async def test_kubo_default_urls(
                 # print(f"Loaded encoded data length: {len(loaded_encoded_data)}")
                 result = dag_cbor.decode(loaded_encoded_data)
                 # print(f"Decoded result: {result}")
-                assert (
-                    data == result
-                ), f"Data mismatch for codec {codec} with default URLs"
+                assert data == result, (
+                    f"Data mismatch for codec {codec} with default URLs"
+                )
             except Exception as e:
                 pytest.fail(
                     f"Error during KuboCAS default URL test (codec: {codec}): {e}"

--- a/tests/test_zarr_ipfs.py
+++ b/tests/test_zarr_ipfs.py
@@ -6,6 +6,7 @@ import xarray as xr
 import pytest
 import zarr
 import zarr.core.buffer
+from dag_cbor.ipld import IPLDKind
 
 from py_hamt import HAMT, KuboCAS
 
@@ -58,7 +59,7 @@ def random_zarr_dataset():
 # This test also collects miscellaneous statistics about performance, run with pytest -s to see these statistics being printed out
 @pytest.mark.asyncio(loop_scope="session")  # ← match the loop of the fixture
 async def test_write_read(
-    create_ipfs,
+    create_ipfs: tuple[str, str],
     random_zarr_dataset: xr.Dataset,
 ):  # noqa for fixture which is imported above but then "redefined"
     rpc_base_url, gateway_base_url = create_ipfs
@@ -82,7 +83,7 @@ async def test_write_read(
         print(f"Total time in seconds: {elapsed:.2f}")
         print("=== Root CID")
         await hamt.make_read_only()
-        cid = hamt.root_node_id
+        cid: IPLDKind = hamt.root_node_id
         print(cid)
 
         print("=== Reading data back in and checking if identical")
@@ -116,7 +117,7 @@ async def test_write_read(
         assert not zhs.supports_partial_writes
         assert not zhs.supports_deletes
 
-        hamt_keys = set()
+        hamt_keys: set[str] = set()
         async for k in zhs.hamt.keys():
             hamt_keys.add(k)
 
@@ -143,16 +144,16 @@ async def test_write_read(
                 zarr.core.buffer.default_buffer_prototype(), []
             )
 
-        previous_zarr_json = await zhs.get(
+        previous_zarr_json: zarr.core.buffer.Buffer | None = await zhs.get(
             "zarr.json", zarr.core.buffer.default_buffer_prototype()
         )
         assert previous_zarr_json is not None
         # Setting a metadata file that should always exist should not change anything
         await zhs.set_if_not_exists(
             "zarr.json",
-            np.array([b"a"], dtype=np.bytes_),  # type: ignore
-        )  # type: ignore np.arrays, if dtype is bytes, is usable as a zarr buffer
-        zarr_json_now = await zhs.get(
+            np.array([b"a"], dtype=np.bytes_),  # type: ignore[arg-type]
+        )  # np.arrays, if dtype is bytes, is usable as a zarr buffer
+        zarr_json_now: zarr.core.buffer.Buffer | None = await zhs.get(
             "zarr.json", zarr.core.buffer.default_buffer_prototype()
         )
         assert zarr_json_now is not None

--- a/tests/test_zarr_ipfs.py
+++ b/tests/test_zarr_ipfs.py
@@ -120,20 +120,20 @@ async def test_write_read(
         async for k in zhs.hamt.keys():
             hamt_keys.add(k)
 
-        zhs_keys: set[str] = set()
+        zhs_keys_1: set[str] = set()
         async for k in zhs.list():
-            zhs_keys.add(k)
-        assert hamt_keys == zhs_keys
+            zhs_keys_1.add(k)
+        assert hamt_keys == zhs_keys_1
 
-        zhs_keys: set[str] = set()
+        zhs_keys_2: set[str] = set()
         async for k in zhs.list():
-            zhs_keys.add(k)
-        assert hamt_keys == zhs_keys
+            zhs_keys_2.add(k)
+        assert hamt_keys == zhs_keys_2
 
-        zhs_keys: set[str] = set()
+        zhs_keys_3: set[str] = set()
         async for k in zhs.list_prefix(""):
-            zhs_keys.add(k)
-        assert hamt_keys == zhs_keys
+            zhs_keys_3.add(k)
+        assert hamt_keys == zhs_keys_3
 
         with pytest.raises(NotImplementedError):
             await zhs.set_partial_values([])
@@ -164,11 +164,11 @@ async def test_write_read(
         await zhs.delete("zarr.json")
         # doing a duplicate delete should not result in an error
         await zhs.delete("zarr.json")
-        zhs_keys: set[str] = set()
+        zhs_keys_4: set[str] = set()
         async for k in zhs.list():
-            zhs_keys.add(k)
-        assert hamt_keys != zhs_keys
-        assert "zarr.json" not in zhs_keys
+            zhs_keys_4.add(k)
+        assert hamt_keys != zhs_keys_4
+        assert "zarr.json" not in zhs_keys_4
 
         await zhs.set_if_not_exists("zarr.json", previous_zarr_json)
         zarr_json_now = await zhs.get(

--- a/uv.lock
+++ b/uv.lock
@@ -1371,6 +1371,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pandas-stubs"
+version = "2.2.3.250527"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "types-pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/0d/5fe7f7f3596eb1c2526fea151e9470f86b379183d8b9debe44b2098651ca/pandas_stubs-2.2.3.250527.tar.gz", hash = "sha256:e2d694c4e72106055295ad143664e5c99e5815b07190d1ff85b73b13ff019e63", size = 106312 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/f8/46141ba8c9d7064dc5008bfb4a6ae5bd3c30e4c61c28b5c5ed485bf358ba/pandas_stubs-2.2.3.250527-py3-none-any.whl", hash = "sha256:cd0a49a95b8c5f944e605be711042a4dd8550e2c559b43d70ba2c4b524b66163", size = 159683 },
+]
+
+[[package]]
 name = "partd"
 version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1562,6 +1575,7 @@ dev = [
     { name = "mypy" },
     { name = "numpy" },
     { name = "pandas" },
+    { name = "pandas-stubs" },
     { name = "pdoc" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1588,6 +1602,7 @@ dev = [
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "numpy", specifier = ">=2.1.3" },
     { name = "pandas", specifier = ">=2.2.3" },
+    { name = "pandas-stubs", specifier = ">=2.2.3.250527" },
     { name = "pdoc", specifier = ">=15.0.0" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-asyncio", specifier = ">=0.25.3" },
@@ -2029,6 +2044,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/d4/f8ac1f5bd22c15fad3b527e025ce219bd526acdbd903f52053df2baecc8b/tornado-6.4.1-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a02a08cc7a9314b006f653ce40483b9b3c12cda222d6a46d4ac63bb6c9057698", size = 436882 },
     { url = "https://files.pythonhosted.org/packages/4b/3e/a8124c21cc0bbf144d7903d2a0cadab15cadaf683fa39a0f92bc567f0d4d/tornado-6.4.1-cp38-abi3-win32.whl", hash = "sha256:d9a566c40b89757c9aa8e6f032bcdb8ca8795d7c1a9762910c722b1635c9de4d", size = 438092 },
     { url = "https://files.pythonhosted.org/packages/d9/2f/3f2f05e84a7aff787a96d5fb06821323feb370fe0baed4db6ea7b1088f32/tornado-6.4.1-cp38-abi3-win_amd64.whl", hash = "sha256:b24b8982ed444378d7f21d563f4180a2de31ced9d8d84443907a0a64da2072e7", size = 438532 },
+]
+
+[[package]]
+name = "types-pytz"
+version = "2025.2.0.20250516"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/72/b0e711fd90409f5a76c75349055d3eb19992c110f0d2d6aabbd6cfbc14bf/types_pytz-2025.2.0.20250516.tar.gz", hash = "sha256:e1216306f8c0d5da6dafd6492e72eb080c9a166171fa80dd7a1990fd8be7a7b3", size = 10940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ba/e205cd11c1c7183b23c97e4bcd1de7bc0633e2e867601c32ecfc6ad42675/types_pytz-2025.2.0.20250516-py3-none-any.whl", hash = "sha256:e0e0c8a57e2791c19f718ed99ab2ba623856b11620cb6b637e5f62ce285a7451", size = 10136 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1129,6 +1129,40 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/43/d5e49a86afa64bd3839ea0d5b9c7103487007d728e1293f52525d6d5486a/mypy-1.15.0.tar.gz", hash = "sha256:404534629d51d3efea5c800ee7c42b72a6554d6c400e6a79eafe15d11341fd43", size = 3239717 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/3a/03c74331c5eb8bd025734e04c9840532226775c47a2c39b56a0c8d4f128d/mypy-1.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:aea39e0583d05124836ea645f412e88a5c7d0fd77a6d694b60d9b6b2d9f184fd", size = 10793981 },
+    { url = "https://files.pythonhosted.org/packages/f0/1a/41759b18f2cfd568848a37c89030aeb03534411eef981df621d8fad08a1d/mypy-1.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2f2147ab812b75e5b5499b01ade1f4a81489a147c01585cda36019102538615f", size = 9749175 },
+    { url = "https://files.pythonhosted.org/packages/12/7e/873481abf1ef112c582db832740f4c11b2bfa510e829d6da29b0ab8c3f9c/mypy-1.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce436f4c6d218a070048ed6a44c0bbb10cd2cc5e272b29e7845f6a2f57ee4464", size = 11455675 },
+    { url = "https://files.pythonhosted.org/packages/b3/d0/92ae4cde706923a2d3f2d6c39629134063ff64b9dedca9c1388363da072d/mypy-1.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8023ff13985661b50a5928fc7a5ca15f3d1affb41e5f0a9952cb68ef090b31ee", size = 12410020 },
+    { url = "https://files.pythonhosted.org/packages/46/8b/df49974b337cce35f828ba6fda228152d6db45fed4c86ba56ffe442434fd/mypy-1.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1124a18bc11a6a62887e3e137f37f53fbae476dc36c185d549d4f837a2a6a14e", size = 12498582 },
+    { url = "https://files.pythonhosted.org/packages/13/50/da5203fcf6c53044a0b699939f31075c45ae8a4cadf538a9069b165c1050/mypy-1.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:171a9ca9a40cd1843abeca0e405bc1940cd9b305eaeea2dda769ba096932bb22", size = 9366614 },
+    { url = "https://files.pythonhosted.org/packages/6a/9b/fd2e05d6ffff24d912f150b87db9e364fa8282045c875654ce7e32fffa66/mypy-1.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:93faf3fdb04768d44bf28693293f3904bbb555d076b781ad2530214ee53e3445", size = 10788592 },
+    { url = "https://files.pythonhosted.org/packages/74/37/b246d711c28a03ead1fd906bbc7106659aed7c089d55fe40dd58db812628/mypy-1.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:811aeccadfb730024c5d3e326b2fbe9249bb7413553f15499a4050f7c30e801d", size = 9753611 },
+    { url = "https://files.pythonhosted.org/packages/a6/ac/395808a92e10cfdac8003c3de9a2ab6dc7cde6c0d2a4df3df1b815ffd067/mypy-1.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98b7b9b9aedb65fe628c62a6dc57f6d5088ef2dfca37903a7d9ee374d03acca5", size = 11438443 },
+    { url = "https://files.pythonhosted.org/packages/d2/8b/801aa06445d2de3895f59e476f38f3f8d610ef5d6908245f07d002676cbf/mypy-1.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c43a7682e24b4f576d93072216bf56eeff70d9140241f9edec0c104d0c515036", size = 12402541 },
+    { url = "https://files.pythonhosted.org/packages/c7/67/5a4268782eb77344cc613a4cf23540928e41f018a9a1ec4c6882baf20ab8/mypy-1.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:baefc32840a9f00babd83251560e0ae1573e2f9d1b067719479bfb0e987c6357", size = 12494348 },
+    { url = "https://files.pythonhosted.org/packages/83/3e/57bb447f7bbbfaabf1712d96f9df142624a386d98fb026a761532526057e/mypy-1.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b9378e2c00146c44793c98b8d5a61039a048e31f429fb0eb546d93f4b000bedf", size = 9373648 },
+    { url = "https://files.pythonhosted.org/packages/09/4e/a7d65c7322c510de2c409ff3828b03354a7c43f5a8ed458a7a131b41c7b9/mypy-1.15.0-py3-none-any.whl", hash = "sha256:5469affef548bd1895d86d3bf10ce2b44e33d86923c29e4d675b3e323437ea3e", size = 2221777 },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963 },
+]
+
+[[package]]
 name = "narwhals"
 version = "1.38.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1525,6 +1559,7 @@ dependencies = [
 dev = [
     { name = "hypothesis" },
     { name = "memray" },
+    { name = "mypy" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "pdoc" },
@@ -1550,6 +1585,7 @@ requires-dist = [
 dev = [
     { name = "hypothesis", specifier = ">=6.115.5" },
     { name = "memray", specifier = ">=1.14.0" },
+    { name = "mypy", specifier = ">=1.15.0" },
     { name = "numpy", specifier = ">=2.1.3" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "pdoc", specifier = ">=15.0.0" },


### PR DESCRIPTION
Adds types across codebase, puts it in pre-commit, which adds it then to out github action (which runs pre-commit). Adding full typing allows the module to be compiled with [mypyc](https://github.com/mypyc/mypyc) for high performance C like execution

- Something to note I that I had to do runtime verification checking on InMemoryCAS since mypy correctly noted that our code violated the Liskov Substitution Principle (aka your child class can’t have more specific argument types than the parent), the alternative here is to not inherit from content addressed store I guess. Since it’s not exported maybe it’s not a big deal. 