### PR TITLE
Add multi-gateway support to KuboCAS

### DIFF
--- a/py_hamt/store.py
+++ b/py_hamt/store.py
@@ -120,6 +120,8 @@ class KuboCAS(ContentAddressedStore):
       the internally-created session.
     - **rpc_base_url / gateway_base_url** (str | None): override daemon
       endpoints (defaults match the local daemon ports).
+    - **gateway_base_urls** (list[str] | None): optional list of additional
+      gateway URLs to try in parallel when loading blocks.
 
     ...
     """
@@ -137,6 +139,7 @@ class KuboCAS(ContentAddressedStore):
         session: aiohttp.ClientSession | None = None,
         rpc_base_url: str | None = KUBO_DEFAULT_LOCAL_RPC_BASE_URL,
         gateway_base_url: str | None = KUBO_DEFAULT_LOCAL_GATEWAY_BASE_URL,
+        gateway_base_urls: list[str] | None = None,
         concurrency: int = 32,
         *,
         headers: dict[str, str] | None = None,
@@ -188,7 +191,10 @@ class KuboCAS(ContentAddressedStore):
 
         self.rpc_url: str = f"{rpc_base_url}/api/v0/add?hash={self.hasher}&pin=false"
         """@private"""
-        self.gateway_base_url: str = f"{gateway_base_url}/ipfs/"
+        self.gateway_base_urls: list[str] = (
+            gateway_base_urls if gateway_base_urls else [gateway_base_url]
+        )
+        self.gateway_base_url: str = self.gateway_base_urls[0]
         """@private"""
 
         self._session_per_loop: dict[
@@ -262,8 +268,31 @@ class KuboCAS(ContentAddressedStore):
     async def load(self, id: IPLDKind) -> bytes:
         """@private"""
         cid = cast(CID, id)  # CID is definitely in the IPLDKind type
-        url: str = self.gateway_base_url + str(cid)
-        async with self._sem:  # throttle gateway
-            async with self._loop_session().get(url) as resp:
-                resp.raise_for_status()
-                return await resp.read()
+
+        async def _fetch(base: str) -> bytes:
+            url: str = base + str(cid)
+            async with self._sem:
+                async with self._loop_session().get(url) as resp:
+                    resp.raise_for_status()
+                    return await resp.read()
+
+        if len(self.gateway_base_urls) == 1:
+            return await _fetch(self.gateway_base_urls[0])
+
+        tasks = [asyncio.create_task(_fetch(base)) for base in self.gateway_base_urls]
+        try:
+            for coro in asyncio.as_completed(tasks):
+                try:
+                    result = await coro
+                except Exception:  # keep racing
+                    continue
+                else:
+                    for t in tasks:
+                        if not t.done():
+                            t.cancel()
+                    return result
+        finally:
+            for t in tasks:
+                if not t.done():
+                    t.cancel()
+        raise RuntimeError("All gateway requests failed")

--- a/py_hamt/store.py
+++ b/py_hamt/store.py
@@ -121,7 +121,8 @@ class KuboCAS(ContentAddressedStore):
     - **rpc_base_url / gateway_base_url** (str | None): override daemon
       endpoints (defaults match the local daemon ports).
     - **gateway_base_urls** (list[str] | None): optional list of additional
-      gateway URLs to try in parallel when loading blocks.
+      gateway URLs to try in parallel when loading blocks. Each base URL is
+      normalized to end with ``/ipfs/``.
 
     ...
     """
@@ -191,10 +192,14 @@ class KuboCAS(ContentAddressedStore):
 
         self.rpc_url: str = f"{rpc_base_url}/api/v0/add?hash={self.hasher}&pin=false"
         """@private"""
-        self.gateway_base_urls: list[str] = (
-            gateway_base_urls if gateway_base_urls else [gateway_base_url]
-        )
-        self.gateway_base_url: str = self.gateway_base_urls[0]
+
+        def _normalize(url: str) -> str:
+            """Ensure URL ends with '/ipfs/'."""
+            return url.rstrip("/") + "/ipfs/"
+
+        bases = gateway_base_urls if gateway_base_urls else [gateway_base_url]
+        self.gateway_base_urls = [_normalize(u) for u in bases]
+        self.gateway_base_url = self.gateway_base_urls[0]
         """@private"""
 
         self._session_per_loop: dict[

--- a/tests/test_kubo_cas.py
+++ b/tests/test_kubo_cas.py
@@ -144,3 +144,20 @@ async def test_kubo_cas(create_ipfs, data: IPLDKind):  # noqa
                 cid = await kubo_cas.save(dag_cbor.encode(data), codec=codec_typed)
                 result = dag_cbor.decode(await kubo_cas.load(cid))
                 assert data == result
+
+
+@pytest.mark.ipfs
+@pytest.mark.asyncio(loop_scope="session")
+async def test_kubo_multi_gateway(create_ipfs, global_client_session):
+    """Verify that multiple gateway URLs work."""
+    rpc_url, gateway_url = create_ipfs
+
+    async with KuboCAS(
+        rpc_base_url=rpc_url,
+        gateway_base_url=gateway_url,
+        gateway_base_urls=[gateway_url, gateway_url],
+        session=global_client_session,
+    ) as kubo_cas:
+        cid = await kubo_cas.save(b"hello", codec="raw")
+        result = await kubo_cas.load(cid)
+        assert result == b"hello"


### PR DESCRIPTION
## Summary
- allow `KuboCAS` to receive multiple gateway URLs and race requests
- test that multi-gateway loading works

## Testing
- `bash run-checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_683fe3c2c39c8322b1fc24eb58ce9ab2

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/dClimate/py-hamt/63)
<!-- GitContextEnd -->