### PR TITLE
Fix unclosed session warning

### DIFF
--- a/tests/test_kubocas_session.py
+++ b/tests/test_kubocas_session.py
@@ -98,5 +98,4 @@ async def test_distinct_loops_get_distinct_sessions():
 
     # Clean‑up
     await kubo.aclose()
-    if not secondary_session.closed:
-        await asyncio.to_thread(secondary_session.close)
+    assert secondary_session.closed


### PR DESCRIPTION
## Summary
- ensure all internal aiohttp sessions are closed across event loops
- update session test to assert new cleanup behaviour

## Testing
- `uv run pytest --cov=py_hamt tests/`
- `uv run pre-commit run --all-files --show-diff-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6847b839853483228c2a7308252fa03f