### PR TITLE
Add chunker validation to KuboCAS

### DIFF
--- a/py_hamt/store_httpx.py
+++ b/py_hamt/store_httpx.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Literal, Tuple, cast
 
@@ -120,6 +121,9 @@ class KuboCAS(ContentAddressedStore):
       for the internally-created client.
     - **rpc_base_url / gateway_base_url** (str | None): override daemon
       endpoints (defaults match the local daemon ports).
+    - **chunker** (str): chunking algorithm specification for Kubo's `add`
+      RPC. Accepted formats are `"size-<positive int>"`, `"rabin"`, or
+      `"rabin-<min>-<avg>-<max>"`.
 
     ...
     """
@@ -179,6 +183,11 @@ class KuboCAS(ContentAddressedStore):
         These are the first part of the url, defaults that refer to the default that kubo launches with on a local machine are provided.
         """
 
+        chunker_pattern = r"(?:size-[1-9]\d*|rabin(?:-[1-9]\d*-[1-9]\d*-[1-9]\d*)?)"
+        if re.fullmatch(chunker_pattern, chunker) is None:
+            raise ValueError("Invalid chunker specification")
+        self.chunker: str = chunker
+
         self.hasher: str = hasher
         """The hash function to send to IPFS when storing bytes. Cannot be changed after initialization. The default blake3 follows the default hashing algorithm used by HAMT."""
 
@@ -196,7 +205,7 @@ class KuboCAS(ContentAddressedStore):
         else:
             gateway_base_url = f"{gateway_base_url}/ipfs/"
 
-        self.rpc_url: str = f"{rpc_base_url}/api/v0/add?hash={self.hasher}&chunker={chunker}&pin=false"
+        self.rpc_url: str = f"{rpc_base_url}/api/v0/add?hash={self.hasher}&chunker={self.chunker}&pin=false"
         """@private"""
         self.gateway_base_url: str = gateway_base_url
         """@private"""

--- a/tests/test_kubo_cas.py
+++ b/tests/test_kubo_cas.py
@@ -143,3 +143,23 @@ async def test_kubo_cas(create_ipfs, data: IPLDKind):  # noqa
                 cid = await kubo_cas.save(dag_cbor.encode(data), codec=codec_typed)
                 result = dag_cbor.decode(await kubo_cas.load(cid))
                 assert data == result
+
+
+def test_chunker_valid_patterns():
+    valid = ["size-1", "size-1024", "rabin", "rabin-16-32-64"]
+    for chunker in valid:
+        cas = KuboCAS(
+            chunker=chunker,
+            rpc_base_url="http://127.0.0.1:5001",
+            gateway_base_url="http://127.0.0.1:8080",
+        )
+        assert f"chunker={chunker}" in cas.rpc_url
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    ["", "size-0", "size--1", "rabin-1-2", "foo", "rabin-1-2-0"],
+)
+def test_chunker_invalid_patterns(invalid):
+    with pytest.raises(ValueError, match="Invalid chunker specification"):
+        KuboCAS(chunker=invalid)


### PR DESCRIPTION
## Summary
- validate chunker string in `KuboCAS.__init__`
- document allowed chunker formats
- use validated value when building RPC URL
- test chunker validation logic

## Testing
- `uv run pytest --cov=py_hamt tests/` *(fails: tests/test_public_gateway.py due to network restrictions)*
- `uv run pre-commit run --all-files --show-diff-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6865382eb060832498c6dfc8a8851f6b