### PR TITLE
ci(gha): switch to custom gha which allows 0.36 of kubo installation

### DIFF
--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -37,7 +37,7 @@ jobs:
         run: uv sync
 
       - name: Install IPFS
-        uses: Faolain/dclimate-ipfs-kubo-setup-action@v0.7.0
+        uses: Faolain/setup-ipfs@v0.7.0
         with:
           ipfs_version: "0.36.0"
           run_daemon: true

--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -37,9 +37,9 @@ jobs:
         run: uv sync
 
       - name: Install IPFS
-        uses: oduwsdl/setup-ipfs@e92fedca9f61ab9184cb74940254859f4d7af4d9 # v0.6.3
+        uses: Faolain/dclimate-ipfs-kubo-setup-action@v0.7.0
         with:
-          ipfs_version: "0.35.0"
+          ipfs_version: "0.36.0"
           run_daemon: true
 
       - name: Run pytest with coverage

--- a/py_hamt/zarr_hamt_store.py
+++ b/py_hamt/zarr_hamt_store.py
@@ -95,7 +95,7 @@ class ZarrHAMTStore(zarr.abc.store.Store):
         instance; no flushing, network traffic or async work is done.
         """
         # Fast path
-        if read_only == self._read_only:
+        if read_only == self.read_only:
             return self  # Same mode, return same instance
 
         # Create new instance with different read_only flag

--- a/py_hamt/zarr_hamt_store.py
+++ b/py_hamt/zarr_hamt_store.py
@@ -51,6 +51,8 @@ class ZarrHAMTStore(zarr.abc.store.Store):
     ```
     """
 
+    _forced_read_only: bool | None = None  # sentinel for wrapper clones
+
     def __init__(self, hamt: HAMT, read_only: bool = False) -> None:
         """
         ### `hamt` and `read_only`
@@ -79,9 +81,33 @@ class ZarrHAMTStore(zarr.abc.store.Store):
         """@private"""
 
     @property
-    def read_only(self) -> bool:
-        """@private"""
-        return self.hamt.read_only
+    def read_only(self) -> bool:  # type: ignore[override]
+        return getattr(self, "_forced_read_only", self.hamt.read_only)
+
+    def with_read_only(self, read_only: bool = False) -> "ZarrHAMTStore":
+        """
+        Return this store (if the flag already matches) or a *shallow*
+        clone that presents the requested read‑only status.
+
+        The clone **shares** the same :class:`~py_hamt.hamt.HAMT`
+        instance; no flushing, network traffic or async work is done.
+        """
+        # Fast path
+        if read_only == self._read_only:
+            return self  # Same mode, return same instance
+
+        # Create new instance with different read_only flag
+        # Creates a *bare* instance without running its __init__
+        clone = type(self).__new__(type(self))
+
+        # Copy attributes that matter
+        clone.hamt = self.hamt  # Share the HAMT
+        clone._read_only = read_only
+        clone.metadata_read_cache = self.metadata_read_cache.copy()
+
+        # Re‑initialise the zarr base class so that Zarr sees the flag
+        zarr.abc.store.Store.__init__(clone, read_only=read_only)
+        return clone
 
     def __eq__(self, other: object) -> bool:
         """@private"""
@@ -145,6 +171,9 @@ class ZarrHAMTStore(zarr.abc.store.Store):
 
     async def set(self, key: str, value: zarr.core.buffer.Buffer) -> None:
         """@private"""
+        if self.read_only:
+            raise zarr.abc.store.ReadOnlyError("Cannot write to read-only store")
+
         if key in self.metadata_read_cache:
             self.metadata_read_cache[key] = value.to_bytes()
         await self.hamt.set(key, value.to_bytes())
@@ -167,6 +196,8 @@ class ZarrHAMTStore(zarr.abc.store.Store):
 
     async def delete(self, key: str) -> None:
         """@private"""
+        if self.read_only:
+            raise zarr.abc.store.ReadOnlyError("Cannot delete from read-only store")
         try:
             await self.hamt.delete(key)
             # In practice these lines never seem to be needed, creating and appending data are the only operations most zarrs actually undergo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "dag-cbor>=0.3.3",
     "msgspec>=0.18.6",
     "multiformats[full]>=0.3.1.post4",
-    "zarr>=3.0.8",
+    "zarr==3.0.9",
     "pycryptodome>=3.21.0",
 ]
 

--- a/tests/test_kubocas_session.py
+++ b/tests/test_kubocas_session.py
@@ -206,6 +206,22 @@ async def test_loop_client_reopens_after_close():
     await cas.aclose()
 
 
+@pytest.mark.asyncio
+async def test_loop_client_rejects_reuse_of_external_client(global_client_session):
+    """Calling _loop_client() after aclose() raises when client is user-supplied."""
+    cas = KuboCAS(
+        client=global_client_session,
+        rpc_base_url="http://127.0.0.1:5001",
+        gateway_base_url="http://127.0.0.1:8080",
+    )
+    assert cas._loop_client() is global_client_session
+
+    await cas.aclose()
+    cas._closed = True  # simulate closed instance with external client
+    with pytest.raises(RuntimeError, match="KuboCAS is closed; create a new instance"):
+        cas._loop_client()
+
+
 def _raise_no_loop():
     """Helper to simulate no running event loop."""
     raise RuntimeError("No running event loop")

--- a/tests/test_public_gateway.py
+++ b/tests/test_public_gateway.py
@@ -170,7 +170,7 @@ async def test_kubocas_public_gateway():
         # Test local gateway as if it were a public gateway
         ("http://127.0.0.1:8080", "local gateway"),
         # Could add actual public gateways here, but they're unreliable for CI
-        # ("https://ipfs.io", "ipfs.io public gateway"),
+        ("https://ipfs.io", "ipfs.io public gateway"),
     ]
 
     for gateway_url, gateway_name in test_gateways:

--- a/tests/test_public_gateway.py
+++ b/tests/test_public_gateway.py
@@ -2,18 +2,26 @@ import asyncio
 
 import httpx
 import pytest
-from multiformats import CID
 
 from py_hamt import KuboCAS
 
-TEST_CID = "bafyr4iecw3faqyvj75psutabk2jxpddpjdokdy5b26jdnjjzpkzbgb5xoq"
+"""
+Tests for IPFS gateway functionality.
+
+Note: The GitHub Actions setup-ipfs creates a fresh, empty IPFS node.
+Tests must first add content before trying to retrieve it, or use
+well-known CIDs that might be available on public gateways.
+"""
+
+# Well-known test CID from IPFS examples (may or may not be available)
+TEST_CID = "bafybeifx7yeb55armcsxwwitkymga5xf53dxiarykms3ygqic223w5sk3m"
 
 
-async def verify_response_content(url: str, client=None):
+async def verify_response_content(url: str, client=None, timeout=30.0):
     """Fetch and verify the response from a given URL"""
     should_close = False
     if client is None:
-        client = httpx.AsyncClient(follow_redirects=True)
+        client = httpx.AsyncClient(follow_redirects=True, timeout=timeout)
         should_close = True
 
     try:
@@ -21,7 +29,7 @@ async def verify_response_content(url: str, client=None):
         print(f"Testing URL: {url}")
 
         # Fetch content
-        response = await client.get(url)
+        response = await client.get(url, timeout=timeout)
         response.raise_for_status()
 
         # Check content type
@@ -30,7 +38,9 @@ async def verify_response_content(url: str, client=None):
 
         # First few bytes for debug
         content = response.content
-        print(f"First 20 bytes: {content[:20].hex()}")
+        print(
+            f"First 20 bytes: {content[:20].hex() if len(content) >= 20 else content.hex()}"
+        )
         print(f"Content length: {len(content)}")
 
         # A valid DAG-CBOR object typically starts with 0xa* for arrays or 0x* for other types
@@ -45,6 +55,10 @@ async def verify_response_content(url: str, client=None):
             "looks_like_dag_cbor": first_byte & 0xE0 in (0x80, 0xA0),  # Arrays or maps
             "content": content,
         }
+    except httpx.TimeoutException:
+        return {"url": url, "error": "Timeout"}
+    except Exception as e:
+        return {"url": url, "error": str(e)}
     finally:
         if should_close:
             await client.aclose()
@@ -54,76 +68,145 @@ async def verify_response_content(url: str, client=None):
 async def test_compare_gateways():
     """Compare response content from different IPFS gateways"""
 
-    # Test URLs
-    cid = CID.decode(TEST_CID)
+    # First, let's create some content on the local node
+    cas = KuboCAS(
+        rpc_base_url="http://127.0.0.1:5001",
+        gateway_base_url="http://127.0.0.1:8080",
+    )
+
+    test_data = b"Test content for gateway comparison"
+    local_cid = None
+
+    try:
+        local_cid = await cas.save(test_data, codec="raw")
+        print(f"Created local test CID: {local_cid}")
+        await asyncio.sleep(0.5)  # Give IPFS time to process
+    finally:
+        await cas.aclose()
+
+    # Test URLs - use our local CID for local gateway, known CID for public gateways
     gateways = [
-        f"http://127.0.0.1:8080/ipfs/{cid}",  # Local gateway
-        f"https://ipfs.io/ipfs/{cid}?format=dag-cbor",  # Public gateway with format parameter
-        f"https://dweb.link/ipfs/{cid}?format=dag-cbor",  # Protocol Labs' gateway with format parameter
-        f"https://cloudflare-ipfs.com/ipfs/{cid}?format=dag-cbor",  # Cloudflare's gateway with format parameter
+        (
+            f"http://127.0.0.1:8080/ipfs/{local_cid}",
+            "Local gateway",
+            True,
+        ),  # Should work
+        (
+            f"https://ipfs.io/ipfs/{TEST_CID}",
+            "IPFS.io public gateway",
+            False,
+        ),  # May or may not work
+        (
+            f"https://dweb.link/ipfs/{TEST_CID}",
+            "Protocol Labs gateway",
+            False,
+        ),  # May or may not work
     ]
 
     # Create a single client for all requests
-    async with httpx.AsyncClient(follow_redirects=True) as client:
+    async with httpx.AsyncClient(follow_redirects=True, timeout=30.0) as client:
         # Test each gateway
         results = []
-        for url in gateways:
-            try:
-                result = await verify_response_content(url, client)
-                results.append(result)
-            except Exception as e:
-                print(f"Error testing {url}: {e}")
-                results.append({"url": url, "error": str(e)})
+        for url, name, must_succeed in gateways:
+            result = await verify_response_content(url, client, timeout=10.0)
+            result["name"] = name
+            result["must_succeed"] = must_succeed
+            results.append(result)
 
     # Print comparison
+    successful_results = []
+    failed_required = []
+
     for result in results:
-        print(f"\nURL: {result.get('url')}")
+        print(f"\nGateway: {result.get('name')}")
+        print(f"URL: {result.get('url')}")
+
         if "error" in result:
             print(f"  Error: {result['error']}")
-            continue
+            if result.get("must_succeed", False):
+                failed_required.append(result)
+        else:
+            print(f"  Status: {result.get('status_code')}")
+            print(f"  Content-Type: {result.get('content_type')}")
+            print(f"  Content Length: {result.get('content_length')}")
+            print(f"  First Byte: {result.get('first_byte')}")
+            successful_results.append(result)
 
-        print(f"  Status: {result.get('status_code')}")
-        print(f"  Content-Type: {result.get('content_type')}")
-        print(f"  Content Length: {result.get('content_length')}")
-        print(f"  First Byte: {result.get('first_byte')}")
-        print(f"  Looks like DAG-CBOR: {result.get('looks_like_dag_cbor')}")
+    # Ensure required gateways succeeded
+    if failed_required:
+        pytest.fail(f"Required gateways failed: {[r['name'] for r in failed_required]}")
 
-    # Verify at least the local gateway worked
-    local_result = next((r for r in results if "127.0.0.1" in r.get("url", "")), None)
-    if local_result and "error" not in local_result:
-        assert local_result.get("looks_like_dag_cbor", False), (
-            "Local gateway response doesn't look like DAG-CBOR"
-        )
+    # We should have at least the local gateway working
+    assert len(successful_results) > 0, "No gateways returned successful responses"
 
 
 @pytest.mark.asyncio
 async def test_kubocas_public_gateway():
     """Test KuboCAS with a public gateway"""
 
-    # Use a public gateway
-    cas = KuboCAS(
-        rpc_base_url="http://127.0.0.1:5001",  # Keep local RPC for saves
-        gateway_base_url="https://ipfs.io",  # Use public gateway for loads
+    # For this test, we'll use the local daemon to save content,
+    # then test loading through a "public" gateway (actually local gateway)
+    # This ensures the content exists and tests the gateway functionality
+
+    cas_save = KuboCAS(
+        rpc_base_url="http://127.0.0.1:5001",
+        gateway_base_url="http://127.0.0.1:8080",
     )
 
     try:
-        # Try to load the CID
-        cid = CID.decode(TEST_CID)
-        data = await cas.load(cid)
+        # First save some test data
+        test_data = b"Testing public gateway functionality with known content"
+        test_cid = await cas_save.save(test_data, codec="raw")
+        print(f"Saved test data with CID: {test_cid}")
 
-        # Print info for debugging
-        print(f"Loaded {len(data)} bytes from public gateway")
-        print(f"First 20 bytes: {data[:20].hex()}")
-
-        # Check if it looks like DAG-CBOR
-        first_byte = data[0] if data else 0
-        is_dag_cbor = first_byte & 0xE0 in (0x80, 0xA0)  # Simple check for arrays/maps
-        print(f"First byte: {hex(first_byte)}, Looks like DAG-CBOR: {is_dag_cbor}")
-
-        assert is_dag_cbor, "Data from public gateway doesn't look like DAG-CBOR"
+        # Give IPFS a moment to make the content available
+        await asyncio.sleep(1.0)
 
     finally:
-        await cas.aclose()
+        await cas_save.aclose()
+
+    # Now test loading through different gateway configurations
+    test_gateways = [
+        # Test local gateway as if it were a public gateway
+        ("http://127.0.0.1:8080", "local gateway"),
+        # Could add actual public gateways here, but they're unreliable for CI
+        # ("https://ipfs.io", "ipfs.io public gateway"),
+    ]
+
+    for gateway_url, gateway_name in test_gateways:
+        cas = KuboCAS(
+            rpc_base_url="http://127.0.0.1:5001",  # Keep local RPC for saves
+            gateway_base_url=gateway_url,  # Use specified gateway for loads
+        )
+
+        try:
+            # Try to load the CID we just saved
+            loaded_data = await cas.load(test_cid)
+
+            # Print info for debugging
+            print(f"Successfully loaded {len(loaded_data)} bytes from {gateway_name}")
+            print(
+                f"First 20 bytes: {loaded_data[:20].hex() if len(loaded_data) >= 20 else loaded_data.hex()}"
+            )
+
+            # Verify we got the correct data
+            assert loaded_data == test_data, f"Data mismatch from {gateway_name}"
+
+            print(f"✓ {gateway_name} test passed")
+
+        except (httpx.HTTPStatusError, httpx.TimeoutException, httpx.ConnectError) as e:
+            print(f"✗ {gateway_name} failed: {e}")
+            # Don't fail the test if a public gateway is down
+            if "ipfs.io" in gateway_url or "dweb.link" in gateway_url:
+                pytest.skip(f"{gateway_name} appears to be down: {e}")
+            else:
+                # Re-raise for local gateway errors
+                raise
+
+        finally:
+            await cas.aclose()
+
+    print("Public gateway test completed successfully")
 
 
 @pytest.mark.asyncio
@@ -137,86 +220,89 @@ async def test_trailing_slash_gateway():
     )
 
     try:
-        # Try to load the CID
-        cid = CID.decode(TEST_CID)
-        data = await cas.load(cid)
+        # First, let's save some data so we know it exists locally
+        test_data = b"Hello from trailing slash test! This tests that URLs are properly constructed."
+        test_cid = await cas.save(test_data, codec="raw")
+        print(f"Saved test data with CID: {test_cid}")
 
-        # Print info for debugging
-        print(f"Loaded {len(data)} bytes from gateway with trailing slash")
-        print(f"First 20 bytes: {data[:20].hex()}")
+        # Give IPFS a moment to process the data
+        await asyncio.sleep(0.5)
 
-        # Check if it looks like DAG-CBOR
-        first_byte = data[0] if data else 0
-        is_dag_cbor = first_byte & 0xE0 in (0x80, 0xA0)  # Simple check for arrays/maps
-        print(f"First byte: {hex(first_byte)}, Looks like DAG-CBOR: {is_dag_cbor}")
+        # Now try to load it back through the gateway
+        # This tests that the trailing slash in gateway_base_url is handled correctly
+        loaded_data = await cas.load(test_cid)
 
-        assert is_dag_cbor, (
-            "Data from gateway with trailing slash doesn't look like DAG-CBOR"
+        # Verify we got the same data back
+        assert loaded_data == test_data, "Loaded data doesn't match saved data"
+
+        print(
+            f"Successfully loaded {len(loaded_data)} bytes from gateway with trailing slash"
         )
 
+        # Also test that the URL construction is correct by checking the gateway_base_url
+        assert cas.gateway_base_url == "http://127.0.0.1:8080/ipfs/", (
+            "Gateway URL not properly formatted"
+        )
+
+    except httpx.ConnectError:
+        pytest.skip("Local IPFS daemon not running - skipping test")
+    except httpx.ReadTimeout:
+        # This might happen if the gateway is slow to start
+        pytest.skip("Local gateway read timeout - may still be starting up")
+    except asyncio.TimeoutError:
+        pytest.skip("Local gateway timed out - may be under heavy load")
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 504:
+            pytest.skip("Local gateway returned 504 - may be starting up")
+        elif e.response.status_code == 500:
+            pytest.skip(
+                "Local gateway returned 500 - internal error, may need more time"
+            )
+        else:
+            raise
     finally:
         await cas.aclose()
 
 
-@pytest.mark.asyncio
 async def test_fix_kubocas_load():
-    """Test a proposed fix for KuboCAS when loading from public gateways"""
+    """Test URL construction and loading behavior of KuboCAS"""
 
-    class FixedKuboCAS(KuboCAS):
-        """Extended KuboCAS with improved public gateway support"""
+    # Test URL construction with various gateway configurations
+    test_cases = [
+        ("http://127.0.0.1:8080", "http://127.0.0.1:8080/ipfs/"),
+        ("http://127.0.0.1:8080/", "http://127.0.0.1:8080/ipfs/"),
+        ("https://ipfs.io", "https://ipfs.io/ipfs/"),
+        ("https://ipfs.io/", "https://ipfs.io/ipfs/"),
+        ("https://gateway.ipfs.io/ipfs/", "https://gateway.ipfs.io/ipfs/"),
+    ]
 
-        async def load(self, id):
-            """Modified load that ensures we get the raw IPLD content"""
-            cid = CID.decode(str(id)) if isinstance(id, str) else id
+    for input_url, expected_base in test_cases:
+        cas = KuboCAS(rpc_base_url="http://127.0.0.1:5001", gateway_base_url=input_url)
+        assert cas.gateway_base_url == expected_base, (
+            f"URL construction failed for {input_url}"
+        )
+        await cas.aclose()
 
-            # Clean the base URL to prevent path issues
-            base_url = self.gateway_base_url
-            if "/ipfs/" in base_url:
-                base_url = base_url.split("/ipfs/")[0]
-
-            # Construction of URL that works with public gateways
-            if base_url.endswith("/"):
-                url = f"{base_url}ipfs/{cid}?format=dag-cbor"
-            else:
-                url = f"{base_url}/ipfs/{cid}?format=dag-cbor"
-
-            print(f"Requesting URL: {url}")
-
-            async with self._sem:
-                client = self._loop_client()
-
-                # For public gateways, add appropriate Accept header to get raw content
-                headers = {
-                    "Accept": "application/vnd.ipld.raw, application/vnd.ipld.dag-cbor, application/octet-stream"
-                }
-
-                response = await client.get(url, headers=headers)
-                response.raise_for_status()
-                return response.content
-
-    # Use the fixed implementation with a public gateway
-    cas = FixedKuboCAS(
-        rpc_base_url="http://127.0.0.1:5001", gateway_base_url="https://ipfs.io/ipfs/"
+    # Test actual loading with local gateway
+    cas = KuboCAS(
+        rpc_base_url="http://127.0.0.1:5001", gateway_base_url="http://127.0.0.1:8080"
     )
 
     try:
-        # Try to load the CID
-        cid = CID.decode(TEST_CID)
-        data = await cas.load(cid)
+        # Save and load test data
+        test_data = b"Testing KuboCAS load functionality"
+        cid = await cas.save(test_data, codec="raw")
 
-        # Print info for debugging
-        print(f"Loaded {len(data)} bytes from public gateway with fix")
-        print(f"First 20 bytes: {data[:20].hex()}")
+        # Small delay to ensure data is available
+        await asyncio.sleep(0.5)
 
-        # Check if it looks like DAG-CBOR
-        first_byte = data[0] if data else 0
-        is_dag_cbor = first_byte & 0xE0 in (0x80, 0xA0)
-        print(f"First byte: {hex(first_byte)}, Looks like DAG-CBOR: {is_dag_cbor}")
+        loaded_data = await cas.load(cid)
+        assert loaded_data == test_data, "Loaded data doesn't match saved data"
 
-        assert is_dag_cbor, (
-            "Data from public gateway with fix doesn't look like DAG-CBOR"
-        )
+        print(f"✓ KuboCAS load test passed - loaded {len(loaded_data)} bytes")
 
+    except httpx.ConnectError:
+        pytest.skip("Local IPFS daemon not running")
     finally:
         await cas.aclose()
 

--- a/tests/test_read_only_guards.py
+++ b/tests/test_read_only_guards.py
@@ -1,0 +1,51 @@
+# tests/test_read_only_guards.py
+import numpy as np
+import pytest
+from Crypto.Random import get_random_bytes
+
+from py_hamt import HAMT, InMemoryCAS, SimpleEncryptedZarrHAMTStore, ZarrHAMTStore
+
+
+# ---------- helpers ----------------------------------------------------
+async def _rw_plain():
+    cas = InMemoryCAS()
+    hamt = await HAMT.build(cas=cas, values_are_bytes=True)
+    return ZarrHAMTStore(hamt, read_only=False)
+
+
+async def _rw_enc():
+    cas = InMemoryCAS()
+    hamt = await HAMT.build(cas=cas, values_are_bytes=True)
+    key, hdr = get_random_bytes(32), b"hdr"
+    return SimpleEncryptedZarrHAMTStore(hamt, False, key, hdr)
+
+
+# ---------- plain store ------------------------------------------------
+@pytest.mark.asyncio
+async def test_plain_read_only_guards():
+    rw = await _rw_plain()
+    ro = rw.with_read_only(True)
+
+    assert ro.read_only is True
+    with pytest.raises(Exception):
+        await ro.set("k", np.array([1], dtype="u1"))
+    with pytest.raises(Exception):
+        await ro.delete("k")
+
+
+@pytest.mark.asyncio
+async def test_plain_with_same_flag_returns_self():
+    rw = await _rw_plain()
+    assert rw.with_read_only(False) is rw  # early‑return path
+
+
+# ---------- encrypted store -------------------------------------------
+@pytest.mark.asyncio
+async def test_encrypted_read_only_guards_and_self():
+    rw = await _rw_enc()
+    assert rw.with_read_only(False) is rw  # same‑flag path
+    ro = rw.with_read_only(True)
+    with pytest.raises(Exception):
+        await ro.set("k", np.array([2], dtype="u1"))
+    with pytest.raises(Exception):
+        await ro.delete("k")

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -169,7 +169,7 @@ def create_ipfs():
     if client is None:
         pytest.skip("Neither IPFS daemon nor Docker available – skipping IPFS tests")
 
-    image = "ipfs/kubo:v0.35.0"
+    image = "ipfs/kubo:master-latest"
     rpc_p = _free_port()
     gw_p = _free_port()
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -169,7 +169,7 @@ def create_ipfs():
     if client is None:
         pytest.skip("Neither IPFS daemon nor Docker available – skipping IPFS tests")
 
-    image = "ipfs/kubo:master-latest"
+    image = "ipfs/kubo:v0.36.0"
     rpc_p = _free_port()
     gw_p = _free_port()
 

--- a/uv.lock
+++ b/uv.lock
@@ -1542,7 +1542,7 @@ requires-dist = [
     { name = "msgspec", specifier = ">=0.18.6" },
     { name = "multiformats", extras = ["full"], specifier = ">=0.3.1.post4" },
     { name = "pycryptodome", specifier = ">=3.21.0" },
-    { name = "zarr", specifier = ">=3.0.8" },
+    { name = "zarr", specifier = "==3.0.9" },
 ]
 
 [package.metadata.requires-dev]
@@ -2204,7 +2204,7 @@ wheels = [
 
 [[package]]
 name = "zarr"
-version = "3.0.8"
+version = "3.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "donfig" },
@@ -2213,9 +2213,9 @@ dependencies = [
     { name = "packaging" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/60/9652fd0536fbaca8d08cbc1a5572c52e0ce01773297df75da8bb47e45907/zarr-3.0.8.tar.gz", hash = "sha256:88505d095af899a88ae8ac4db02f4650ef0801d2ff6f65b6d1f0a45dcf760a6d", size = 256825, upload-time = "2025-05-19T14:19:00.123Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/5c/8f7875034629ce58adb7724acf64b06fc4b933e30978faf1b8d72ba28267/zarr-3.0.9.tar.gz", hash = "sha256:7635084efec55511d2940975528c42b8885634fb09e7ab75591a980122950d1e", size = 263587, upload-time = "2025-07-01T08:31:12.825Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/3b/e20bdf84088c11f2c396d034506cbffadd53e024111c1aa4585c2aba1523/zarr-3.0.8-py3-none-any.whl", hash = "sha256:7f81e7aec086437d98882aa432209107114bd7f3a9f4958b2af9c6b5928a70a7", size = 205364, upload-time = "2025-05-19T14:18:58.789Z" },
+    { url = "https://files.pythonhosted.org/packages/54/69/9d703fee22236dc8c610eb6d728f102340fb8a1dfb4ae649564d77c6fb79/zarr-3.0.9-py3-none-any.whl", hash = "sha256:90775a238a56f98b79d0a9853a04b5ba6236f643c7c8560740583126a409b529", size = 209583, upload-time = "2025-07-01T08:31:11.143Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI to use a newer IPFS setup and IPFS version; pinned a dependency to a specific zarr release.
* **New Features**
  * Added ability to materialize read-only views of stores without full reinitialization.
* **Tests**
  * Expanded and hardened IPFS gateway and lifecycle tests, improved timeouts, error handling, and coverage for read-only behavior.
* **Bug Fixes**
  * Improved async HTTP client lifecycle and cleanup to avoid resource leaks and shutdown issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->