### PR TITLE
deps: address required missing key in zarr upgrade

### DIFF
--- a/py_hamt/encryption_hamt_store.py
+++ b/py_hamt/encryption_hamt_store.py
@@ -180,3 +180,23 @@ class SimpleEncryptedZarrHAMTStore(ZarrHAMTStore):
         # Encrypt it
         encrypted_bytes = self._encrypt(raw_bytes)
         await self.hamt.set(key, encrypted_bytes)
+
+    # we only need to override because we have extra ctor args
+    def with_read_only(self, read_only: bool = False) -> "SimpleEncryptedZarrHAMTStore":  # noqa: D401
+        if read_only == self.read_only:
+            return self
+
+        new_hamt = HAMT(
+            cas=self.hamt.cas,
+            root_node_id=self.hamt.root_node_id,
+            read_only=read_only,
+            values_are_bytes=self.hamt.values_are_bytes,
+            max_bucket_size=self.hamt.max_bucket_size,
+            hash_fn=self.hamt.hash_fn,
+        )
+        return type(self)(
+            new_hamt,
+            read_only,
+            encryption_key=self.encryption_key,
+            header=self.header,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "dag-cbor>=0.3.3",
     "msgspec>=0.18.6",
     "multiformats[full]>=0.3.1.post4",
-    "zarr>=3.0.8",
+    "zarr==3.0.9",
     "pycryptodome>=3.21.0",
 ]
 

--- a/tests/test_with_read_only.py
+++ b/tests/test_with_read_only.py
@@ -1,0 +1,19 @@
+import pytest
+
+from py_hamt import HAMT, InMemoryCAS, ZarrHAMTStore
+
+
+@pytest.mark.asyncio
+async def test_with_read_only_roundtrip():
+    cas = InMemoryCAS()
+    hamt_rw = await HAMT.build(cas=cas, values_are_bytes=True)
+    store_rw = ZarrHAMTStore(hamt_rw, read_only=False)
+
+    # clone → RO
+    store_ro = store_rw.with_read_only(True)
+    assert store_ro.read_only is True
+    assert store_ro is not store_rw
+    # clone back → RW
+    store_rw2 = store_ro.with_read_only(False)
+    assert store_rw2.read_only is False
+    assert store_rw2.hamt.root_node_id == store_rw.hamt.root_node_id

--- a/uv.lock
+++ b/uv.lock
@@ -1542,7 +1542,7 @@ requires-dist = [
     { name = "msgspec", specifier = ">=0.18.6" },
     { name = "multiformats", extras = ["full"], specifier = ">=0.3.1.post4" },
     { name = "pycryptodome", specifier = ">=3.21.0" },
-    { name = "zarr", specifier = ">=3.0.8" },
+    { name = "zarr", specifier = "==3.0.9" },
 ]
 
 [package.metadata.requires-dev]
@@ -2204,7 +2204,7 @@ wheels = [
 
 [[package]]
 name = "zarr"
-version = "3.0.8"
+version = "3.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "donfig" },
@@ -2213,9 +2213,9 @@ dependencies = [
     { name = "packaging" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/60/9652fd0536fbaca8d08cbc1a5572c52e0ce01773297df75da8bb47e45907/zarr-3.0.8.tar.gz", hash = "sha256:88505d095af899a88ae8ac4db02f4650ef0801d2ff6f65b6d1f0a45dcf760a6d", size = 256825, upload-time = "2025-05-19T14:19:00.123Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/5c/8f7875034629ce58adb7724acf64b06fc4b933e30978faf1b8d72ba28267/zarr-3.0.9.tar.gz", hash = "sha256:7635084efec55511d2940975528c42b8885634fb09e7ab75591a980122950d1e", size = 263587, upload-time = "2025-07-01T08:31:12.825Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/3b/e20bdf84088c11f2c396d034506cbffadd53e024111c1aa4585c2aba1523/zarr-3.0.8-py3-none-any.whl", hash = "sha256:7f81e7aec086437d98882aa432209107114bd7f3a9f4958b2af9c6b5928a70a7", size = 205364, upload-time = "2025-05-19T14:18:58.789Z" },
+    { url = "https://files.pythonhosted.org/packages/54/69/9d703fee22236dc8c610eb6d728f102340fb8a1dfb4ae649564d77c6fb79/zarr-3.0.9-py3-none-any.whl", hash = "sha256:90775a238a56f98b79d0a9853a04b5ba6236f643c7c8560740583126a409b529", size = 209583, upload-time = "2025-07-01T08:31:11.143Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Tests work locally but maybe we want to add this to https://github.com/dClimate/py-hamt/pull/76 (?) which has more extensive changes to handle possible dangling/unclosed sockets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to toggle between read-only and writable modes for stores, allowing users to easily switch access permissions while preserving data integrity.

* **Bug Fixes**
  * None.

* **Tests**
  * Introduced tests to verify correct behavior when switching between read-only and writable store modes.

* **Chores**
  * Updated dependency requirements to use an exact version of Zarr (3.0.9) for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->