### PR TITLE
Ci/update zarr 3.0.9

### DIFF
--- a/py_hamt/zarr_hamt_store.py
+++ b/py_hamt/zarr_hamt_store.py
@@ -95,7 +95,7 @@ class ZarrHAMTStore(zarr.abc.store.Store):
         instance; no flushing, network traffic or async work is done.
         """
         # Fast path
-        if read_only == self._read_only:
+        if read_only == self.read_only:
             return self  # Same mode, return same instance
 
         # Create new instance with different read_only flag

--- a/py_hamt/zarr_hamt_store.py
+++ b/py_hamt/zarr_hamt_store.py
@@ -51,6 +51,8 @@ class ZarrHAMTStore(zarr.abc.store.Store):
     ```
     """
 
+    _forced_read_only: bool | None = None  # sentinel for wrapper clones
+
     def __init__(self, hamt: HAMT, read_only: bool = False) -> None:
         """
         ### `hamt` and `read_only`
@@ -79,9 +81,33 @@ class ZarrHAMTStore(zarr.abc.store.Store):
         """@private"""
 
     @property
-    def read_only(self) -> bool:
-        """@private"""
-        return self.hamt.read_only
+    def read_only(self) -> bool:  # type: ignore[override]
+        return getattr(self, "_forced_read_only", self.hamt.read_only)
+
+    def with_read_only(self, read_only: bool = False) -> "ZarrHAMTStore":
+        """
+        Return this store (if the flag already matches) or a *shallow*
+        clone that presents the requested read‑only status.
+
+        The clone **shares** the same :class:`~py_hamt.hamt.HAMT`
+        instance; no flushing, network traffic or async work is done.
+        """
+        # Fast path
+        if read_only == self._read_only:
+            return self  # Same mode, return same instance
+
+        # Create new instance with different read_only flag
+        # Creates a *bare* instance without running its __init__
+        clone = type(self).__new__(type(self))
+
+        # Copy attributes that matter
+        clone.hamt = self.hamt  # Share the HAMT
+        clone._read_only = read_only
+        clone.metadata_read_cache = self.metadata_read_cache.copy()
+
+        # Re‑initialise the zarr base class so that Zarr sees the flag
+        zarr.abc.store.Store.__init__(clone, read_only=read_only)
+        return clone
 
     def __eq__(self, other: object) -> bool:
         """@private"""
@@ -145,6 +171,9 @@ class ZarrHAMTStore(zarr.abc.store.Store):
 
     async def set(self, key: str, value: zarr.core.buffer.Buffer) -> None:
         """@private"""
+        if self.read_only:
+            raise zarr.abc.store.ReadOnlyError("Cannot write to read-only store")
+
         if key in self.metadata_read_cache:
             self.metadata_read_cache[key] = value.to_bytes()
         await self.hamt.set(key, value.to_bytes())
@@ -167,6 +196,8 @@ class ZarrHAMTStore(zarr.abc.store.Store):
 
     async def delete(self, key: str) -> None:
         """@private"""
+        if self.read_only:
+            raise zarr.abc.store.ReadOnlyError("Cannot delete from read-only store")
         try:
             await self.hamt.delete(key)
             # In practice these lines never seem to be needed, creating and appending data are the only operations most zarrs actually undergo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "dag-cbor>=0.3.3",
     "msgspec>=0.18.6",
     "multiformats[full]>=0.3.1.post4",
-    "zarr>=3.0.8",
+    "zarr==3.0.9",
     "pycryptodome>=3.21.0",
 ]
 

--- a/tests/test_kubocas_session.py
+++ b/tests/test_kubocas_session.py
@@ -206,6 +206,22 @@ async def test_loop_client_reopens_after_close():
     await cas.aclose()
 
 
+@pytest.mark.asyncio
+async def test_loop_client_rejects_reuse_of_external_client(global_client_session):
+    """Calling _loop_client() after aclose() raises when client is user-supplied."""
+    cas = KuboCAS(
+        client=global_client_session,
+        rpc_base_url="http://127.0.0.1:5001",
+        gateway_base_url="http://127.0.0.1:8080",
+    )
+    assert cas._loop_client() is global_client_session
+
+    await cas.aclose()
+    cas._closed = True  # simulate closed instance with external client
+    with pytest.raises(RuntimeError, match="KuboCAS is closed; create a new instance"):
+        cas._loop_client()
+
+
 def _raise_no_loop():
     """Helper to simulate no running event loop."""
     raise RuntimeError("No running event loop")

--- a/tests/test_read_only_guards.py
+++ b/tests/test_read_only_guards.py
@@ -1,0 +1,51 @@
+# tests/test_read_only_guards.py
+import numpy as np
+import pytest
+from Crypto.Random import get_random_bytes
+
+from py_hamt import HAMT, InMemoryCAS, SimpleEncryptedZarrHAMTStore, ZarrHAMTStore
+
+
+# ---------- helpers ----------------------------------------------------
+async def _rw_plain():
+    cas = InMemoryCAS()
+    hamt = await HAMT.build(cas=cas, values_are_bytes=True)
+    return ZarrHAMTStore(hamt, read_only=False)
+
+
+async def _rw_enc():
+    cas = InMemoryCAS()
+    hamt = await HAMT.build(cas=cas, values_are_bytes=True)
+    key, hdr = get_random_bytes(32), b"hdr"
+    return SimpleEncryptedZarrHAMTStore(hamt, False, key, hdr)
+
+
+# ---------- plain store ------------------------------------------------
+@pytest.mark.asyncio
+async def test_plain_read_only_guards():
+    rw = await _rw_plain()
+    ro = rw.with_read_only(True)
+
+    assert ro.read_only is True
+    with pytest.raises(Exception):
+        await ro.set("k", np.array([1], dtype="u1"))
+    with pytest.raises(Exception):
+        await ro.delete("k")
+
+
+@pytest.mark.asyncio
+async def test_plain_with_same_flag_returns_self():
+    rw = await _rw_plain()
+    assert rw.with_read_only(False) is rw  # early‑return path
+
+
+# ---------- encrypted store -------------------------------------------
+@pytest.mark.asyncio
+async def test_encrypted_read_only_guards_and_self():
+    rw = await _rw_enc()
+    assert rw.with_read_only(False) is rw  # same‑flag path
+    ro = rw.with_read_only(True)
+    with pytest.raises(Exception):
+        await ro.set("k", np.array([2], dtype="u1"))
+    with pytest.raises(Exception):
+        await ro.delete("k")

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -169,7 +169,7 @@ def create_ipfs():
     if client is None:
         pytest.skip("Neither IPFS daemon nor Docker available – skipping IPFS tests")
 
-    image = "ipfs/kubo:v0.35.0"
+    image = "ipfs/kubo:master-latest"
     rpc_p = _free_port()
     gw_p = _free_port()
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -169,7 +169,7 @@ def create_ipfs():
     if client is None:
         pytest.skip("Neither IPFS daemon nor Docker available – skipping IPFS tests")
 
-    image = "ipfs/kubo:master-latest"
+    image = "ipfs/kubo:v0.36.0"
     rpc_p = _free_port()
     gw_p = _free_port()
 

--- a/uv.lock
+++ b/uv.lock
@@ -1542,7 +1542,7 @@ requires-dist = [
     { name = "msgspec", specifier = ">=0.18.6" },
     { name = "multiformats", extras = ["full"], specifier = ">=0.3.1.post4" },
     { name = "pycryptodome", specifier = ">=3.21.0" },
-    { name = "zarr", specifier = ">=3.0.8" },
+    { name = "zarr", specifier = "==3.0.9" },
 ]
 
 [package.metadata.requires-dev]
@@ -2204,7 +2204,7 @@ wheels = [
 
 [[package]]
 name = "zarr"
-version = "3.0.8"
+version = "3.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "donfig" },
@@ -2213,9 +2213,9 @@ dependencies = [
     { name = "packaging" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/60/9652fd0536fbaca8d08cbc1a5572c52e0ce01773297df75da8bb47e45907/zarr-3.0.8.tar.gz", hash = "sha256:88505d095af899a88ae8ac4db02f4650ef0801d2ff6f65b6d1f0a45dcf760a6d", size = 256825, upload-time = "2025-05-19T14:19:00.123Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/5c/8f7875034629ce58adb7724acf64b06fc4b933e30978faf1b8d72ba28267/zarr-3.0.9.tar.gz", hash = "sha256:7635084efec55511d2940975528c42b8885634fb09e7ab75591a980122950d1e", size = 263587, upload-time = "2025-07-01T08:31:12.825Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/3b/e20bdf84088c11f2c396d034506cbffadd53e024111c1aa4585c2aba1523/zarr-3.0.8-py3-none-any.whl", hash = "sha256:7f81e7aec086437d98882aa432209107114bd7f3a9f4958b2af9c6b5928a70a7", size = 205364, upload-time = "2025-05-19T14:18:58.789Z" },
+    { url = "https://files.pythonhosted.org/packages/54/69/9d703fee22236dc8c610eb6d728f102340fb8a1dfb4ae649564d77c6fb79/zarr-3.0.9-py3-none-any.whl", hash = "sha256:90775a238a56f98b79d0a9853a04b5ba6236f643c7c8560740583126a409b529", size = 209583, upload-time = "2025-07-01T08:31:11.143Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added methods to support toggling read-only mode for HAMT-based Zarr stores, allowing seamless switching between read and write access.
  * Enhanced test coverage for IPFS gateway interactions, including support for DAG-CBOR content and gateway URL variations.

* **Bug Fixes**
  * Enforced read-only restrictions on Zarr stores, preventing write or delete operations when in read-only mode.
  * Improved cleanup and lifecycle management of HTTP clients, ensuring proper resource release in both synchronous and asynchronous contexts.

* **Tests**
  * Expanded and added tests for edge cases in client cleanup, gateway behavior, and read-only store access.
  * Added tests verifying read-only guard behavior for encrypted and plain stores.
  * Updated test utilities to use the latest IPFS Docker image for more reliable integration testing.

* **Chores**
  * Updated IPFS installation in CI workflows and pinned the "zarr" dependency to version 3.0.9 for improved stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->