### PR TITLE
Allow KuboCAS to reopen after being closed

### DIFF
--- a/tests/test_kubocas_session.py
+++ b/tests/test_kubocas_session.py
@@ -206,6 +206,22 @@ async def test_loop_client_reopens_after_close():
     await cas.aclose()
 
 
+@pytest.mark.asyncio
+async def test_loop_client_rejects_reuse_of_external_client(global_client_session):
+    """Calling _loop_client() after aclose() raises when client is user-supplied."""
+    cas = KuboCAS(
+        client=global_client_session,
+        rpc_base_url="http://127.0.0.1:5001",
+        gateway_base_url="http://127.0.0.1:8080",
+    )
+    assert cas._loop_client() is global_client_session
+
+    await cas.aclose()
+    cas._closed = True  # simulate closed instance with external client
+    with pytest.raises(RuntimeError, match="KuboCAS is closed; create a new instance"):
+        cas._loop_client()
+
+
 def _raise_no_loop():
     """Helper to simulate no running event loop."""
     raise RuntimeError("No running event loop")


### PR DESCRIPTION
## Summary
- allow `_loop_client` to lazily recreate a new httpx client after `aclose`
- test KuboCAS client reopening behaviour

## Testing
- `uv run pre-commit run --all-files --show-diff-on-failure`
- `uv run pytest --cov` *(fails: DeadlineExceeded in test_fuzz; ConnectError in public gateway tests)*
- `uv run pytest tests/test_kubocas_session.py::test_loop_client_reopens_after_close -q`


------
https://chatgpt.com/codex/tasks/task_e_689f55c5b4508324ad8439113bfe0421