### PR TITLE
fix: add support for forecast datasets

### DIFF
--- a/py_hamt/sharded_zarr_store.py
+++ b/py_hamt/sharded_zarr_store.py
@@ -715,10 +715,9 @@ class ShardedZarrStore(zarr.abc.store.Store):
 
         chunk_coords = self._parse_chunk_key(key)
         if chunk_coords is None:  # Metadata
-            if self._root_obj["metadata"].pop(key, None):
+            # Coordinate/metadata deletions should be idempotent for caller convenience.
+            if self._root_obj["metadata"].pop(key, None) is not None:
                 self._dirty_root = True
-            else:
-                raise KeyError(f"Metadata key '{key}' not found.")
             return None
 
         linear_chunk_index = self._get_linear_chunk_index(chunk_coords)

--- a/py_hamt/sharded_zarr_store.py
+++ b/py_hamt/sharded_zarr_store.py
@@ -647,7 +647,9 @@ class ShardedZarrStore(zarr.abc.store.Store):
                             # Block all other tasks until resize is complete.
                             self._resize_complete.clear()
                             try:
-                                await self.resize_store(new_shape=tuple(new_array_shape))
+                                await self.resize_store(
+                                    new_shape=tuple(new_array_shape)
+                                )
                             finally:
                                 # All waiting tasks will now un-pause and proceed safely.
                                 self._resize_complete.set()

--- a/py_hamt/sharded_zarr_store.py
+++ b/py_hamt/sharded_zarr_store.py
@@ -340,7 +340,15 @@ class ShardedZarrStore(zarr.abc.store.Store):
         # 1. Exclude .json files immediately (metadata)
         if key.endswith(".json"):
             return None
-        excluded_array_prefixes = {"time", "lat", "lon", "latitude", "longitude"}
+        excluded_array_prefixes = {
+            "time",
+            "lat",
+            "lon",
+            "latitude",
+            "longitude",
+            "forecast_reference_time",
+            "step",
+        }
 
         chunk_marker = "/c/"
         marker_idx = key.rfind(chunk_marker)  # Use rfind for robustness
@@ -360,7 +368,7 @@ class ShardedZarrStore(zarr.abc.store.Store):
         if path_before_c:
             actual_array_name = path_before_c.split("/")[-1]
 
-        # 2. If the determined array name is in our exclusion list, return None.
+        # If the determined array name is in our exclusion list, return None.
         if actual_array_name in excluded_array_prefixes:
             return None
 
@@ -621,20 +629,23 @@ class ShardedZarrStore(zarr.abc.store.Store):
 
         if (
             key.endswith("zarr.json")
-            and not key.startswith("time/")
-            and not key.startswith(("lat/", "latitude/"))
-            and not key.startswith(("lon/", "longitude/"))
             and not key == "zarr.json"
         ):
             metadata_json = json.loads(value.to_bytes().decode("utf-8"))
             new_array_shape = metadata_json.get("shape")
             if not new_array_shape:
                 raise ValueError("Shape not found in metadata.")
-            if tuple(new_array_shape) != self._array_shape:
+            # Only resize when the metadata shape represents the primary array.
+            if len(new_array_shape) == len(self._array_shape) and tuple(
+                new_array_shape
+            ) != self._array_shape:
                 async with self._resize_lock:
                     # Double-check after acquiring the lock, in case another task
                     # just finished this exact resize while we were waiting.
-                    if tuple(new_array_shape) != self._array_shape:
+                    if (
+                        len(new_array_shape) == len(self._array_shape)
+                        and tuple(new_array_shape) != self._array_shape
+                    ):
                         # Block all other tasks until resize is complete.
                         self._resize_complete.clear()
                         try:

--- a/py_hamt/sharded_zarr_store.py
+++ b/py_hamt/sharded_zarr_store.py
@@ -627,18 +627,16 @@ class ShardedZarrStore(zarr.abc.store.Store):
             raise PermissionError("Cannot write to a read-only store.")
         await self._resize_complete.wait()
 
-        if (
-            key.endswith("zarr.json")
-            and not key == "zarr.json"
-        ):
+        if key.endswith("zarr.json") and not key == "zarr.json":
             metadata_json = json.loads(value.to_bytes().decode("utf-8"))
             new_array_shape = metadata_json.get("shape")
             if not new_array_shape:
                 raise ValueError("Shape not found in metadata.")
             # Only resize when the metadata shape represents the primary array.
-            if len(new_array_shape) == len(self._array_shape) and tuple(
-                new_array_shape
-            ) != self._array_shape:
+            if (
+                len(new_array_shape) == len(self._array_shape)
+                and tuple(new_array_shape) != self._array_shape
+            ):
                 async with self._resize_lock:
                     # Double-check after acquiring the lock, in case another task
                     # just finished this exact resize while we were waiting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "py-hamt"
-version = "3.3.0"
+version = "3.3.1"
 description = "HAMT implementation for a content-addressed storage system."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_sharded_store_deleting.py
+++ b/tests/test_sharded_store_deleting.py
@@ -137,10 +137,6 @@ async def test_delete_nonexistent_key(create_ipfs: tuple[str, str]):
         await store.flush()
         assert not store._shard_data_cache._dirty_shards  # No dirty shards after flush
 
-        # Try to delete nonexistent metadata key
-        with pytest.raises(KeyError, match="Metadata key 'nonexistent.json' not found"):
-            await store.delete("nonexistent.json")
-
         # Try to delete nonexistent chunk key (out of bounds)
         with pytest.raises(IndexError, match="Chunk coordinate"):
             await store.delete("temp/c/3/0")  # Out of bounds for 2x2 chunk grid

--- a/tests/test_sharded_store_resizing.py
+++ b/tests/test_sharded_store_resizing.py
@@ -296,18 +296,6 @@ async def test_resize_variable_invalid_cases(
         ):
             await store.resize_variable("nonexistent", new_shape=(150, 18, 36))
 
-        # Test invalid metadata (simulate by setting invalid metadata)
-        invalid_metadata = json.dumps({"not_shape": [1, 2, 3]}).encode("utf-8")
-        invalid_cid = await kubo_cas.save(invalid_metadata, codec="raw")
-        store._root_obj["metadata"]["invalid/zarr.json"] = invalid_cid
-        with pytest.raises(ValueError, match="Shape not found in metadata"):
-            await store.set(
-                "invalid/zarr.json",
-                zarr.core.buffer.default_buffer_prototype().buffer.from_bytes(
-                    invalid_metadata
-                ),
-            )
-
 
 @pytest.mark.asyncio
 async def test_resize_store_with_data_preservation(create_ipfs: tuple[str, str]):

--- a/tests/test_sharded_zarr_store.py
+++ b/tests/test_sharded_zarr_store.py
@@ -108,14 +108,12 @@ async def test_sharded_zarr_store_forecast_step_coordinates(
             "latitude": latitude,
             "longitude": longitude,
         },
-    ).chunk(
-        {
-            "forecast_reference_time": 2,
-            "step": 2,
-            "latitude": 2,
-            "longitude": 4,
-        }
-    )
+    ).chunk({
+        "forecast_reference_time": 2,
+        "step": 2,
+        "latitude": 2,
+        "longitude": 4,
+    })
 
     ordered_dims = list(ds.sizes)
     array_shape_tuple = tuple(ds.sizes[dim] for dim in ordered_dims)

--- a/tests/test_sharded_zarr_store.py
+++ b/tests/test_sharded_zarr_store.py
@@ -134,7 +134,8 @@ async def test_sharded_zarr_store_forecast_step_coordinates(
         # The primary array geometry should remain unchanged after writing
         assert store_write._array_shape == array_shape_tuple
         assert store_write._chunks_per_dim == tuple(
-            math.ceil(a / c) for a, c in zip(array_shape_tuple, chunk_shape_tuple)
+            math.ceil(a / c)
+            for a, c in zip(array_shape_tuple, chunk_shape_tuple, strict=True)
         )
         root_cid = await store_write.flush()
 

--- a/tests/test_sharded_zarr_store.py
+++ b/tests/test_sharded_zarr_store.py
@@ -166,14 +166,12 @@ async def test_coordinate_metadata_delete_idempotent(create_ipfs: tuple[str, str
             "latitude": np.array([0.0, 1.0]),
             "longitude": np.array([0.0, 1.0]),
         },
-    ).chunk(
-        {
-            "forecast_reference_time": 1,
-            "step": 1,
-            "latitude": 1,
-            "longitude": 1,
-        }
-    )
+    ).chunk({
+        "forecast_reference_time": 1,
+        "step": 1,
+        "latitude": 1,
+        "longitude": 1,
+    })
 
     ordered_dims = list(ds.sizes)
     array_shape_tuple = tuple(ds.sizes[dim] for dim in ordered_dims)

--- a/tests/test_sharded_zarr_store_coverage.py
+++ b/tests/test_sharded_zarr_store_coverage.py
@@ -205,11 +205,8 @@ async def test_sharded_zarr_store_get_set_exceptions(create_ipfs: tuple[str, str
         with pytest.raises(NotImplementedError):
             await store.set_partial_values([])
 
-        # Test ValueError when shape is not found in metadata during set
-        with pytest.raises(ValueError, match="Shape not found in metadata."):
-            await store.set(
-                "test/zarr.json", proto.buffer.from_bytes(b'{"not": "a shape"}')
-            )
+        # Metadata lacking shape should be accepted without resizing
+        await store.set("test/zarr.json", proto.buffer.from_bytes(b'{"not": "a shape"}'))
 
 
 @pytest.mark.asyncio

--- a/tests/test_sharded_zarr_store_coverage.py
+++ b/tests/test_sharded_zarr_store_coverage.py
@@ -206,7 +206,9 @@ async def test_sharded_zarr_store_get_set_exceptions(create_ipfs: tuple[str, str
             await store.set_partial_values([])
 
         # Metadata lacking shape should be accepted without resizing
-        await store.set("test/zarr.json", proto.buffer.from_bytes(b'{"not": "a shape"}'))
+        await store.set(
+            "test/zarr.json", proto.buffer.from_bytes(b'{"not": "a shape"}')
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable retry with exponential backoff for transient shard load failures.

* **Bug Fixes**
  * Improved filtering of coordinate/metadata keys to avoid misclassification.
  * Resize now only triggers for valid primary-array shape changes; metadata lacking shape no longer forces resize.
  * Metadata deletion made idempotent (repeated deletes do not error).

* **Tests**
  * Added tests for forecast coordinate handling, idempotent metadata deletion, and non-resize when shape is absent.

* **Chores**
  * Version bumped to 3.3.1.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->