### PR TITLE
perf: add sparse decode option

### DIFF
--- a/py_hamt/__init__.py
+++ b/py_hamt/__init__.py
@@ -1,7 +1,11 @@
 from .encryption_hamt_store import SimpleEncryptedZarrHAMTStore
 from .hamt import HAMT, blake3_hashfn
 from .hamt_to_sharded_converter import convert_hamt_to_sharded, sharded_converter_cli
-from .sharded_zarr_store import ShardedZarrStore, ShardedZarrV1DeprecationWarning
+from .sharded_zarr_store import (
+    ShardedZarrStore,
+    ShardedZarrV1DeprecationWarning,
+    ShardReadMode,
+)
 from .store_httpx import ContentAddressedStore, InMemoryCAS, KuboCAS
 from .zarr_hamt_store import ZarrHAMTStore
 
@@ -14,6 +18,7 @@ __all__ = [
     "ZarrHAMTStore",
     "SimpleEncryptedZarrHAMTStore",
     "ShardedZarrStore",
+    "ShardReadMode",
     "ShardedZarrV1DeprecationWarning",
     "convert_hamt_to_sharded",
     "sharded_converter_cli",

--- a/py_hamt/sharded_zarr_store.py
+++ b/py_hamt/sharded_zarr_store.py
@@ -89,7 +89,9 @@ def _skip_cbor_item(data: bytes, offset: int) -> int:
     if major_type == 6:
         return _skip_cbor_item(data, offset)
 
-    raise ValueError(f"Unsupported CBOR major type: {major_type}.")
+    raise ValueError(  # pragma: no cover - all CBOR major types are handled above
+        f"Unsupported CBOR major type: {major_type}."
+    )
 
 
 def _read_cbor_list_header(shard_bytes: bytes) -> tuple[int, int]:

--- a/py_hamt/sharded_zarr_store.py
+++ b/py_hamt/sharded_zarr_store.py
@@ -438,7 +438,7 @@ class ShardedZarrStore(zarr.abc.store.Store):
         root_cid: Optional[str] = None,
         *,
         max_cache_memory_bytes: int = 100 * 1024 * 1024,  # 100MB default
-        shard_read_mode: ShardReadMode = "full",
+        shard_read_mode: ShardReadMode = "sparse",
     ):
         """Use the async `open()` classmethod to instantiate this class."""
         super().__init__(read_only=read_only)
@@ -562,7 +562,7 @@ class ShardedZarrStore(zarr.abc.store.Store):
         max_cache_memory_bytes: int = 100 * 1024 * 1024,  # 100MB default
         manifest_version: Optional[str] = None,
         primary_array_path: str = "",
-        shard_read_mode: ShardReadMode = "full",
+        shard_read_mode: ShardReadMode = "sparse",
     ) -> "ShardedZarrStore":
         """
         Asynchronously opens an existing ShardedZarrStore or initializes a new one.

--- a/py_hamt/sharded_zarr_store.py
+++ b/py_hamt/sharded_zarr_store.py
@@ -8,7 +8,17 @@ import warnings
 from collections import OrderedDict, defaultdict
 from collections.abc import AsyncIterator, Iterable
 from dataclasses import dataclass
-from typing import ClassVar, DefaultDict, Dict, List, Optional, Set, Tuple, cast
+from typing import (
+    ClassVar,
+    DefaultDict,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Tuple,
+    cast,
+)
 
 import dag_cbor
 import zarr.abc.store
@@ -26,6 +36,94 @@ SHARDED_ZARR_V2 = "sharded_zarr_v2"
 ZARR_METADATA_SUFFIXES = ("zarr.json", ".zarray", ".zattrs", ".zgroup")
 
 ShardCacheKey = int | tuple[str, int]
+ShardReadMode = Literal["full", "sparse"]
+
+
+def _read_cbor_argument(
+    data: bytes, offset: int, additional_info: int
+) -> tuple[int, int]:
+    if additional_info < 24:
+        return additional_info, offset
+    if additional_info == 24:
+        length = 1
+    elif additional_info == 25:
+        length = 2
+    elif additional_info == 26:
+        length = 4
+    elif additional_info == 27:
+        length = 8
+    else:
+        raise ValueError("Indefinite or reserved CBOR item length is not supported.")
+
+    end = offset + length
+    if end > len(data):
+        raise ValueError("Truncated CBOR item.")
+    return int.from_bytes(data[offset:end], "big"), end
+
+
+def _skip_cbor_item(data: bytes, offset: int) -> int:
+    if offset >= len(data):
+        raise ValueError("Truncated CBOR item.")
+
+    initial_byte = data[offset]
+    offset += 1
+    major_type = initial_byte >> 5
+    additional_info = initial_byte & 0x1F
+    value, offset = _read_cbor_argument(data, offset, additional_info)
+
+    if major_type in {0, 1, 7}:
+        return offset
+    if major_type in {2, 3}:
+        end = offset + value
+        if end > len(data):
+            raise ValueError("Truncated CBOR byte or text string.")
+        return end
+    if major_type == 4:
+        for _ in range(value):
+            offset = _skip_cbor_item(data, offset)
+        return offset
+    if major_type == 5:
+        for _ in range(value * 2):
+            offset = _skip_cbor_item(data, offset)
+        return offset
+    if major_type == 6:
+        return _skip_cbor_item(data, offset)
+
+    raise ValueError(f"Unsupported CBOR major type: {major_type}.")
+
+
+def _read_cbor_list_header(shard_bytes: bytes) -> tuple[int, int]:
+    if not shard_bytes:
+        raise ValueError("Shard bytes are empty.")
+
+    initial_byte = shard_bytes[0]
+    major_type = initial_byte >> 5
+    if major_type != 4:
+        raise ValueError("Shard bytes do not start with a DAG-CBOR list.")
+
+    return _read_cbor_argument(shard_bytes, 1, initial_byte & 0x1F)
+
+
+def decode_shard_entry(shard_bytes: bytes, index: int) -> CID | None:
+    """
+    Decode one entry from a DAG-CBOR shard list without materializing the full list.
+    """
+    if index < 0:
+        raise IndexError("Shard entry index out of range.")
+
+    entry_count, offset = _read_cbor_list_header(shard_bytes)
+    if index >= entry_count:
+        raise IndexError("Shard entry index out of range.")
+
+    for _ in range(index):
+        offset = _skip_cbor_item(shard_bytes, offset)
+
+    entry_start = offset
+    entry_end = _skip_cbor_item(shard_bytes, offset)
+    entry = dag_cbor.decode(shard_bytes[entry_start:entry_end])
+    if entry is not None and not isinstance(entry, CID):
+        raise TypeError("Shard entry contains a non-CID value.")
+    return entry
 
 
 class ShardedZarrV1DeprecationWarning(FutureWarning):
@@ -338,11 +436,18 @@ class ShardedZarrStore(zarr.abc.store.Store):
         root_cid: Optional[str] = None,
         *,
         max_cache_memory_bytes: int = 100 * 1024 * 1024,  # 100MB default
+        shard_read_mode: ShardReadMode = "full",
     ):
         """Use the async `open()` classmethod to instantiate this class."""
         super().__init__(read_only=read_only)
+        if shard_read_mode not in {"full", "sparse"}:
+            raise ValueError(
+                f"Unsupported shard_read_mode: {shard_read_mode!r}. "
+                "Expected 'full' or 'sparse'."
+            )
         self.cas = cas
         self._root_cid = root_cid
+        self.shard_read_mode = shard_read_mode
         self._root_obj: dict = {}
         self._manifest_version = SHARDED_ZARR_V1
 
@@ -455,6 +560,7 @@ class ShardedZarrStore(zarr.abc.store.Store):
         max_cache_memory_bytes: int = 100 * 1024 * 1024,  # 100MB default
         manifest_version: Optional[str] = None,
         primary_array_path: str = "",
+        shard_read_mode: ShardReadMode = "full",
     ) -> "ShardedZarrStore":
         """
         Asynchronously opens an existing ShardedZarrStore or initializes a new one.
@@ -464,7 +570,11 @@ class ShardedZarrStore(zarr.abc.store.Store):
         ``array_shape``/``chunk_shape`` and provide ``chunks_per_shard``.
         """
         store = cls(
-            cas, read_only, root_cid, max_cache_memory_bytes=max_cache_memory_bytes
+            cas,
+            read_only,
+            root_cid,
+            max_cache_memory_bytes=max_cache_memory_bytes,
+            shard_read_mode=shard_read_mode,
         )
         if root_cid:
             await store._load_root_from_cid()
@@ -1230,6 +1340,25 @@ class ShardedZarrStore(zarr.abc.store.Store):
                     f"Failed to fetch shard {shard_idx} after {max_retries} attempts: {e}"
                 ) from e
 
+    async def _load_sparse_shard_entry(
+        self,
+        cache_key: ShardCacheKey,
+        shard_idx: int,
+        shard_cid: str,
+        index_in_shard: int,
+        expected_entries: int,
+    ) -> Optional[CID]:
+        if await self._shard_data_cache.get(cache_key) is not None:
+            return None
+
+        shard_data_bytes = await self.cas.load(shard_cid)
+        entry_count, _ = _read_cbor_list_header(shard_data_bytes)
+        if entry_count != expected_entries:
+            raise ValueError(
+                f"Shard {shard_idx} contains {entry_count} entries; expected {expected_entries}."
+            )
+        return decode_shard_entry(shard_data_bytes, index_in_shard)
+
     def _parse_chunk_key(self, key: str) -> Optional[ChunkKey]:
         if key.endswith(ZARR_METADATA_SUFFIXES):
             return None
@@ -1515,6 +1644,7 @@ class ShardedZarrStore(zarr.abc.store.Store):
         clone._root_cid = self._root_cid
         clone._root_obj = self._root_obj
         clone._manifest_version = self._manifest_version
+        clone.shard_read_mode = self.shard_read_mode
 
         clone._resize_lock = self._resize_lock
         clone._resize_complete = self._resize_complete
@@ -1674,11 +1804,28 @@ class ShardedZarrStore(zarr.abc.store.Store):
                 cache_key = self._cache_key(array_index.array_path, shard_idx)
                 shard_lock = self._shard_locks[cache_key]
                 async with shard_lock:
-                    target_shard_list = await self._load_or_initialize_shard_cache(
-                        shard_idx, array_index.array_path
-                    )
-
-                chunk_cid_obj = target_shard_list[index_in_shard]
+                    cached_shard = await self._shard_data_cache.get(cache_key)
+                    if (
+                        self.read_only
+                        and self.shard_read_mode == "sparse"
+                        and cached_shard is None
+                        and byte_range is None
+                        and 0 <= shard_idx < array_index.num_shards
+                        and array_index.shard_cids[shard_idx] is not None
+                    ):
+                        chunk_cid_obj = await self._load_sparse_shard_entry(
+                            cache_key,
+                            shard_idx,
+                            str(array_index.shard_cids[shard_idx]),
+                            index_in_shard,
+                            array_index.chunks_per_shard,
+                        )
+                    else:
+                        if cached_shard is None:
+                            cached_shard = await self._load_or_initialize_shard_cache(
+                                shard_idx, array_index.array_path
+                            )
+                        chunk_cid_obj = cached_shard[index_in_shard]
                 if chunk_cid_obj is None:
                     legacy_buffer = await self._get_legacy_metadata_chunk(
                         lookup_key, prototype, byte_range

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "py-hamt"
-version = "3.4.0"
+version = "3.4.1"
 description = "HAMT implementation for a content-addressed storage system."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_sharded_zarr_store_v2.py
+++ b/tests/test_sharded_zarr_store_v2.py
@@ -26,6 +26,9 @@ from py_hamt.sharded_zarr_store import (
     ArrayIndex,
     ShardedZarrStore,
     ShardedZarrV1DeprecationWarning,
+    _read_cbor_argument,
+    _read_cbor_list_header,
+    _skip_cbor_item,
     decode_shard_entry,
 )
 from py_hamt.store_httpx import ContentAddressedStore
@@ -119,6 +122,38 @@ def test_decode_shard_entry_rejects_truncated_entry() -> None:
         decode_shard_entry(raw, 0)
 
 
+def test_cbor_helpers_cover_extended_arguments_and_item_types() -> None:
+    assert _read_cbor_argument(b"\x01", 0, 24) == (1, 1)
+    assert _read_cbor_argument(b"\x01\x02", 0, 25) == (258, 2)
+    assert _read_cbor_argument(b"\x00\x00\x01\x02", 0, 26) == (258, 4)
+    assert _read_cbor_argument(b"\x00\x00\x00\x00\x00\x00\x01\x02", 0, 27) == (
+        258,
+        8,
+    )
+
+    with pytest.raises(ValueError, match="reserved"):
+        _read_cbor_argument(b"", 0, 31)
+    with pytest.raises(ValueError, match="Truncated CBOR item"):
+        _read_cbor_argument(b"", 0, 24)
+
+    assert _skip_cbor_item(b"\x00", 0) == 1
+    assert _skip_cbor_item(b"\x20", 0) == 1
+    assert _skip_cbor_item(b"\x63abc", 0) == 4
+    assert _skip_cbor_item(b"\x82\x00\x01", 0) == 3
+    assert _skip_cbor_item(b"\xa1\x00\x01", 0) == 3
+    assert _skip_cbor_item(b"\xc0\x00", 0) == 2
+    assert _skip_cbor_item(b"\xf5", 0) == 1
+
+    with pytest.raises(ValueError, match="Truncated CBOR item"):
+        _skip_cbor_item(b"", 0)
+    with pytest.raises(ValueError, match="byte or text"):
+        _skip_cbor_item(b"\x63ab", 0)
+    with pytest.raises(ValueError, match="DAG-CBOR list"):
+        _read_cbor_list_header(dag_cbor.encode({}))
+    with pytest.raises(ValueError, match="empty"):
+        _read_cbor_list_header(b"")
+
+
 @pytest.mark.asyncio
 async def test_read_only_get_uses_sparse_shard_decode_on_cache_miss(
     monkeypatch: pytest.MonkeyPatch,
@@ -174,6 +209,18 @@ async def test_read_only_get_uses_sparse_shard_decode_on_cache_miss(
     assert sparse_buffer.to_bytes() == expected_chunks[2]
     assert full_decode_calls == 0
     assert await sparse_store._shard_data_cache.get(("a", 0)) is None
+
+    shard_cid = str(sparse_store.array_indices["a"].shard_cids[0])
+    assert (
+        await sparse_store._load_sparse_shard_entry(
+            ("a", 0), 0, shard_cid, 2, expected_entries=4
+        )
+        is not None
+    )
+    with pytest.raises(ValueError, match="expected 3"):
+        await sparse_store._load_sparse_shard_entry(
+            ("a", 0), 0, shard_cid, 2, expected_entries=3
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_sharded_zarr_store_v2.py
+++ b/tests/test_sharded_zarr_store_v2.py
@@ -231,6 +231,21 @@ async def test_read_only_get_uses_sparse_shard_decode_on_cache_miss(
 
 
 @pytest.mark.asyncio
+async def test_full_shard_decode_rejects_unexpected_entry_count() -> None:
+    cas = LocalCIDCAS()
+    shard_cid = await cas.save(dag_cbor.encode([_test_cid(b"only")]), "dag-cbor")
+    store = ShardedZarrStore(cas=cas, read_only=True, shard_read_mode="full")
+
+    with pytest.raises(ValueError, match="Shard 0 contains 1 entries; expected 2"):
+        await store._fetch_and_cache_full_shard(
+            ("a", 0),
+            shard_idx=0,
+            shard_cid=str(shard_cid),
+            expected_entries=2,
+        )
+
+
+@pytest.mark.asyncio
 async def test_read_only_get_defaults_to_sparse_shard_decode() -> None:
     cas = LocalCIDCAS()
     proto = zarr.core.buffer.default_buffer_prototype()

--- a/tests/test_sharded_zarr_store_v2.py
+++ b/tests/test_sharded_zarr_store_v2.py
@@ -26,6 +26,7 @@ from py_hamt.sharded_zarr_store import (
     ArrayIndex,
     ShardedZarrStore,
     ShardedZarrV1DeprecationWarning,
+    decode_shard_entry,
 )
 from py_hamt.store_httpx import ContentAddressedStore
 from py_hamt.zarr_hamt_store import ZarrHAMTStore
@@ -65,6 +66,156 @@ class LocalCIDCAS(ContentAddressedStore):
         if suffix is not None:
             return data[-suffix:]
         return data
+
+
+def _test_cid(label: bytes) -> CID:
+    return CID("base32", 1, "raw", multihash.digest(label, "sha2-256"))
+
+
+def test_decode_shard_entry_matches_full_decode() -> None:
+    shard_entries = [
+        _test_cid(b"first"),
+        _test_cid(b"middle-a"),
+        None,
+        _test_cid(b"middle-b"),
+        _test_cid(b"last"),
+    ]
+    raw = dag_cbor.encode(shard_entries)
+    decoded = dag_cbor.decode(raw)
+
+    assert decode_shard_entry(raw, 0) == decoded[0]
+    assert decode_shard_entry(raw, 3) == decoded[3]
+    assert decode_shard_entry(raw, 4) == decoded[4]
+    assert decode_shard_entry(raw, 2) is None
+
+
+def test_decode_shard_entry_rejects_invalid_index() -> None:
+    raw = dag_cbor.encode([_test_cid(b"only")])
+
+    with pytest.raises(IndexError):
+        decode_shard_entry(raw, -1)
+    with pytest.raises(IndexError):
+        decode_shard_entry(raw, 1)
+
+
+def test_decode_shard_entry_rejects_malformed_non_list_shard() -> None:
+    raw = dag_cbor.encode({"not": "a shard"})
+
+    with pytest.raises(ValueError, match="DAG-CBOR list"):
+        decode_shard_entry(raw, 0)
+
+
+def test_decode_shard_entry_rejects_malformed_cid_entry() -> None:
+    raw = dag_cbor.encode([123])
+
+    with pytest.raises(TypeError, match="non-CID"):
+        decode_shard_entry(raw, 0)
+
+
+def test_decode_shard_entry_rejects_truncated_entry() -> None:
+    raw = dag_cbor.encode([_test_cid(b"truncated")])[:-1]
+
+    with pytest.raises(ValueError):
+        decode_shard_entry(raw, 0)
+
+
+@pytest.mark.asyncio
+async def test_read_only_get_uses_sparse_shard_decode_on_cache_miss(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cas = LocalCIDCAS()
+    proto = zarr.core.buffer.default_buffer_prototype()
+    store = await ShardedZarrStore.open(
+        cas=cas,
+        read_only=False,
+        chunks_per_shard=4,
+        manifest_version=SHARDED_ZARR_V2,
+    )
+    metadata = {
+        "zarr_format": 3,
+        "node_type": "array",
+        "shape": [4],
+        "data_type": "uint8",
+        "chunk_grid": {
+            "name": "regular",
+            "configuration": {"chunk_shape": [1]},
+        },
+    }
+    await store.set(
+        "a/zarr.json", proto.buffer.from_bytes(json.dumps(metadata).encode())
+    )
+    expected_chunks = [b"zero", b"one", b"two", b"three"]
+    for idx, chunk in enumerate(expected_chunks):
+        await store.set(f"a/c/{idx}", proto.buffer.from_bytes(chunk))
+
+    root_cid = await store.flush()
+    full_decode_store = await ShardedZarrStore.open(
+        cas=cas, read_only=True, root_cid=root_cid
+    )
+    await full_decode_store._load_or_initialize_shard_cache(0, "a")
+    full_decode_buffer = await full_decode_store.get("a/c/2", proto)
+    assert full_decode_buffer is not None
+
+    sparse_store = await ShardedZarrStore.open(
+        cas=cas, read_only=True, root_cid=root_cid, shard_read_mode="sparse"
+    )
+    full_decode_calls = 0
+
+    async def fail_full_decode(*args: object, **kwargs: object) -> None:
+        nonlocal full_decode_calls
+        full_decode_calls += 1
+        raise AssertionError("full shard decode should not run")
+
+    monkeypatch.setattr(sparse_store, "_fetch_and_cache_full_shard", fail_full_decode)
+    sparse_buffer = await sparse_store.get("a/c/2", proto)
+
+    assert sparse_buffer is not None
+    assert sparse_buffer.to_bytes() == full_decode_buffer.to_bytes()
+    assert sparse_buffer.to_bytes() == expected_chunks[2]
+    assert full_decode_calls == 0
+    assert await sparse_store._shard_data_cache.get(("a", 0)) is None
+
+
+@pytest.mark.asyncio
+async def test_read_only_get_defaults_to_full_shard_decode() -> None:
+    cas = LocalCIDCAS()
+    proto = zarr.core.buffer.default_buffer_prototype()
+    store = await ShardedZarrStore.open(
+        cas=cas,
+        read_only=False,
+        chunks_per_shard=1,
+        manifest_version=SHARDED_ZARR_V2,
+    )
+    metadata = {
+        "zarr_format": 3,
+        "node_type": "array",
+        "shape": [1],
+        "data_type": "uint8",
+        "chunk_grid": {"name": "regular", "configuration": {"chunk_shape": [1]}},
+    }
+    await store.set(
+        "a/zarr.json", proto.buffer.from_bytes(json.dumps(metadata).encode())
+    )
+    await store.set("a/c/0", proto.buffer.from_bytes(b"value"))
+    root_cid = await store.flush()
+
+    read_store = await ShardedZarrStore.open(cas=cas, read_only=True, root_cid=root_cid)
+    assert read_store.shard_read_mode == "full"
+    buffer = await read_store.get("a/c/0", proto)
+
+    assert buffer is not None
+    assert buffer.to_bytes() == b"value"
+    assert await read_store._shard_data_cache.get(("a", 0)) is not None
+
+
+@pytest.mark.asyncio
+async def test_shard_read_mode_rejects_unknown_value() -> None:
+    with pytest.raises(ValueError, match="shard_read_mode"):
+        await ShardedZarrStore.open(
+            cas=LocalCIDCAS(),
+            read_only=True,
+            shard_read_mode="adaptive",  # type: ignore[arg-type]
+        )
 
 
 def _pyramid_level(data: np.ndarray, *, coord_offset: int = 0) -> xr.Dataset:

--- a/tests/test_sharded_zarr_store_v2.py
+++ b/tests/test_sharded_zarr_store_v2.py
@@ -231,7 +231,7 @@ async def test_read_only_get_uses_sparse_shard_decode_on_cache_miss(
 
 
 @pytest.mark.asyncio
-async def test_read_only_get_defaults_to_full_shard_decode() -> None:
+async def test_read_only_get_defaults_to_sparse_shard_decode() -> None:
     cas = LocalCIDCAS()
     proto = zarr.core.buffer.default_buffer_prototype()
     store = await ShardedZarrStore.open(
@@ -254,12 +254,12 @@ async def test_read_only_get_defaults_to_full_shard_decode() -> None:
     root_cid = await store.flush()
 
     read_store = await ShardedZarrStore.open(cas=cas, read_only=True, root_cid=root_cid)
-    assert read_store.shard_read_mode == "full"
+    assert read_store.shard_read_mode == "sparse"
     buffer = await read_store.get("a/c/0", proto)
 
     assert buffer is not None
     assert buffer.to_bytes() == b"value"
-    assert await read_store._shard_data_cache.get(("a", 0)) is not None
+    assert await read_store._shard_data_cache.get(("a", 0)) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_sharded_zarr_store_v2.py
+++ b/tests/test_sharded_zarr_store_v2.py
@@ -221,6 +221,13 @@ async def test_read_only_get_uses_sparse_shard_decode_on_cache_miss(
         await sparse_store._load_sparse_shard_entry(
             ("a", 0), 0, shard_cid, 2, expected_entries=3
         )
+    await sparse_store._shard_data_cache.put(("a", 0), [None])
+    assert (
+        await sparse_store._load_sparse_shard_entry(
+            ("a", 0), 0, shard_cid, 2, expected_entries=4
+        )
+        is None
+    )
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1521,7 +1521,7 @@ wheels = [
 
 [[package]]
 name = "py-hamt"
-version = "3.3.2"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "dag-cbor" },


### PR DESCRIPTION
Adds an opt-in sparse shard decoding mode for read-only ShardedZarrStore access.
Point requests for small points over long time periods, such as AEGIS, had significant latency because all CIDs within each shard had to be decoded when only needing to access one or two of them.

- Adds ShardReadMode with "full" and "sparse" options.
- The "full" option is the default to preserve existing behavior.
- The "sparse" option only decodes the requested CID within a shard.
- Sparse decoding is used for read-only cache misses without byte-range requests.
- Adds tests covering sparse reads, default full decoding, invalid modes, and malformed shard data.



ERA5 daily t2m point request (30 years of era5 daily)
Root CID: bafyr4icwmb2vbvsifglpeynvacr2wmmm4yomqphmue35xexom22vtyqyji
Rows returned: 10,987

Installed/full-decode baseline: ~61.8s
Local sparse-decode path:       ~6.8s
Speedup:                        ~9.1x
Values matched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an optional shard-reading mode (“sparse”) for read-only access, enabling retrieval of a single shard entry without loading entire shards.
  * Exposed the shard read mode setting through the package’s public API.
* **Bug Fixes**
  * Strengthened shard decoding validation (mode values, malformed payloads, index bounds, and inconsistent entry counts).
* **Tests**
  * Expanded unit and async integration coverage for sparse per-entry decoding and cache behavior, including error cases and default-mode handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->